### PR TITLE
Slicing includes module with version

### DIFF
--- a/src/main/scala/io/appthreat/atom/parsedeps/PythonDependencyParser.scala
+++ b/src/main/scala/io/appthreat/atom/parsedeps/PythonDependencyParser.scala
@@ -11,19 +11,23 @@ import overflowdb.traversal.*
 
 import java.io.File as JFile
 import scala.annotation.tailrec
+
 object PythonDependencyParser extends XDependencyParser {
 
   implicit val engineContext: EngineContext = EngineContext()
 
-  override def parse(cpg: Cpg): DependencySlice = DependencySlice((parseSetupPy(cpg) ++ parseImports(cpg)).toSeq.sorted)
+  override def parse(cpg: Cpg): DependencySlice = DependencySlice(
+    (parseSetupPy(cpg) ++ parseImports(cpg)).toSeq.sortBy(_.name)
+  )
 
-  private def parseSetupPy(cpg: Cpg): Set[String] = {
-    val requirementsPattern = "([\\w_]+)(=>|<=|==|>=|=<|<|>).*".r
+  private def parseSetupPy(cpg: Cpg): Set[ModuleWithVersion] = {
+    val requirementsPattern = "([\\w_]+)((=>|<=|==|>=|=<|<|>|!=).*)".r
 
     def dataSourcesToRequires = (cpg.literal ++ cpg.identifier)
       .where(_.file.name(".*setup.py"))
       .where(_.argumentName("install_requires"))
       .collectAll[CfgNode]
+
     def setupCall = cpg.call("setup").where(_.file.name(".*setup.py"))
 
     def findOriginalDeclaration(xs: Traversal[CfgNode]): Iterable[Literal] =
@@ -38,19 +42,24 @@ object PythonDependencyParser extends XDependencyParser {
           findOriginalDeclaration(c.argument)
         case _ => Iterable()
       }.collectAll[Literal]
-        .toIterable
+        .to(Iterable)
 
     findOriginalDeclaration(setupCall.reachableBy(dataSourcesToRequires))
       .map(x => X2Cpg.stripQuotes(x.code))
       .map {
-        case requirementsPattern(x, _) => x
-        case x                         => x
+        case requirementsPattern(name, versionSpecifiers, _) if versionSpecifiers.contains("==") =>
+          val versions     = versionSpecifiers.split(',').toSeq
+          val exactVersion = versions.find(_.startsWith("==")).get
+          ModuleWithVersion(name, exactVersion.stripPrefix("=="), (versions diff Seq(exactVersion)).mkString(","))
+        case requirementsPattern(name, versionSpecifiers, _) =>
+          ModuleWithVersion(name, versionSpecifiers = versionSpecifiers)
+        case requirementsPattern(name, version) => ModuleWithVersion(name, version)
+        case x                                  => ModuleWithVersion(x)
       }
-      .sorted
       .toSet
   }
 
-  private def parseImports(cpg: Cpg): Set[String] = {
+  private def parseImports(cpg: Cpg): Set[ModuleWithVersion] = {
     val root = ScalaFile(cpg.metaData.root.headOption.getOrElse(JFile.separator)).pathAsString
     // Get a set of local modules to exclude from imports
     val localModuleNames = cpg.file.name
@@ -77,6 +86,7 @@ object PythonDependencyParser extends XDependencyParser {
       .dedup
       .importedEntity
       .flatMap(_.split('.').headOption)
+      .map(x => ModuleWithVersion(x))
       .toSet
   }
 

--- a/src/test/scala/io/appthreat/atom/PythonDependencyScannerTests.scala
+++ b/src/test/scala/io/appthreat/atom/PythonDependencyScannerTests.scala
@@ -1,11 +1,12 @@
 package io.appthreat.atom
 
-import io.appthreat.atom.parsedeps.PythonDependencyParser
+import io.appthreat.atom.parsedeps.{ModuleWithVersion, PythonDependencyParser}
 import io.joern.pysrc2cpg.PySrc2CpgFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.io.File
+
 class PythonDependencyScannerTests extends PySrc2CpgFixture(withOssDataflow = true) {
 
   "dependencies from the `requests` library" should {
@@ -192,7 +193,19 @@ class PythonDependencyScannerTests extends PySrc2CpgFixture(withOssDataflow = tr
 
     "have the modules scanned successfully" in {
       val scanResult = PythonDependencyParser.parse(cpg)
-      scanResult.modules shouldBe Seq("PackageC", "PickyThing", "certifi", "charset_normalizer", "idna", "os", "packageA", "packageB", "socket", "urllib3")
+      scanResult.modules shouldBe List(
+        ModuleWithVersion("PackageC", "1.2.0.dev1+hg.5.b11e5e6f0b0b"),
+        ModuleWithVersion("PickyThing", "2.4c1", "<1.6,>1.9,!=1.9.6,<2.0a0"),
+        ModuleWithVersion("certifi", "", ">=2017.4.17"),
+        ModuleWithVersion("charset_normalizer", "", ">=2,<4"),
+        ModuleWithVersion("idna", "", ">=2.5,<4"),
+        ModuleWithVersion("os"),
+        ModuleWithVersion("packageA", "", ">=1.4.2,<1.9,!=1.5.*,!=1.6.*"),
+        ModuleWithVersion("packageB", "", ">=0.5.0,< 0.7.0"),
+        ModuleWithVersion("socket"),
+        ModuleWithVersion("urllib3"),
+        ModuleWithVersion("urllib3", "", ">=1.21.1,<3")
+      )
     }
   }
 


### PR DESCRIPTION
* Added `ModuleWithVersion` which takes the form of `{"name": "foo", "version": "", "versionSpecifiers": ""}`
* Modified parsedeps tests to reflect this change and validate it