### PR TITLE
Removed Data-Flow Requirement from Python for `parsedeps`

### DIFF
--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -70,6 +70,9 @@ object Atom {
     opt[String]('l', "language")
       .text("source language")
       .action((x, c) => c.copy(language = x))
+    opt[Unit]("withDataDeps")
+      .text("generate the CPG with data-dependencies - defaults to `false`")
+      .action((_, c) => c.copy(withDataDeps = true))
     cmd("parsedeps")
       .action((_, c) => c.copy(parsedeps = true))
     note("Misc")
@@ -169,8 +172,10 @@ object Atom {
             JSConfig(disableDummyTypes = true).withInputPath(config.inputPath).withOutputPath(config.outputAtomFile)
           )
           .map { cpg =>
-            new OssDataFlow(new OssDataFlowOptions(maxNumberOfDefinitions = config.maxNumDef))
-              .run(new LayerCreatorContext(cpg))
+            if (config.withDataDeps) {
+              new OssDataFlow(new OssDataFlowOptions(maxNumberOfDefinitions = config.maxNumDef))
+                .run(new LayerCreatorContext(cpg))
+            }
             new JavaScriptInheritanceNamePass(cpg).createAndApply()
             new ConstClosurePass(cpg).createAndApply()
             new NaiveCallLinker(cpg).createAndApply()
@@ -189,8 +194,10 @@ object Atom {
               )
           )
           .map { cpg =>
-            new OssDataFlow(new OssDataFlowOptions(maxNumberOfDefinitions = config.maxNumDef))
-              .run(new LayerCreatorContext(cpg))
+            if (config.withDataDeps) {
+              new OssDataFlow(new OssDataFlowOptions(maxNumberOfDefinitions = config.maxNumDef))
+                .run(new LayerCreatorContext(cpg))
+            }
             new PythonImportsPass(cpg).createAndApply()
             cpg
           }
@@ -277,6 +284,7 @@ object Atom {
     inputPath: String = "",
     outputAtomFile: String = DEFAULT_ATOM_OUT_FILE,
     outputSliceFile: String = DEFAULT_SLICE_OUT_FILE,
+    withDataDeps: Boolean = false,
     parsedeps: Boolean = false,
     slice: Boolean = false,
     sliceMode: String = "dataflow",

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -71,7 +71,7 @@ object Atom {
       .text("source language")
       .action((x, c) => c.copy(language = x))
     opt[Unit]("withDataDeps")
-      .text("generate the CPG with data-dependencies - defaults to `false`")
+      .text("generate the atom with data-dependencies - defaults to `false`")
       .action((_, c) => c.copy(withDataDeps = true))
     cmd("parsedeps")
       .action((_, c) => c.copy(parsedeps = true))
@@ -91,7 +91,7 @@ object Atom {
         if (sliceModes.contains(x.toLowerCase)) success
         else failure(s"Value <mode> must be one of [${sliceModes.mkString(", ")}]")
       }
-      .action((x, c) => c.copy(sliceMode = x.toLowerCase))
+      .action((x, c) => c.copy(sliceMode = x.toLowerCase, withDataDeps = c.withDataDeps || x.toLowerCase == "dataflow"))
     opt[Int]("max-num-def")
       .text("maximum number of definitions in per-method data flow calculation. Default 2000")
       .action((x, c) => c.copy(maxNumDef = x))

--- a/src/main/scala/io/appthreat/atom/parsedeps/PythonDependencyParser.scala
+++ b/src/main/scala/io/appthreat/atom/parsedeps/PythonDependencyParser.scala
@@ -14,8 +14,6 @@ import scala.annotation.tailrec
 
 object PythonDependencyParser extends XDependencyParser {
 
-  implicit val engineContext: EngineContext = EngineContext()
-
   override def parse(cpg: Cpg): DependencySlice = DependencySlice(
     (parseSetupPy(cpg) ++ parseImports(cpg)).toSeq.sortBy(_.name)
   )
@@ -27,8 +25,6 @@ object PythonDependencyParser extends XDependencyParser {
       .where(_.file.name(".*setup.py"))
       .where(_.argumentName("install_requires"))
       .collectAll[CfgNode]
-
-    def setupCall = cpg.call("setup").where(_.file.name(".*setup.py"))
 
     def findOriginalDeclaration(xs: Traversal[CfgNode]): Iterable[Literal] =
       xs.flatMap {
@@ -44,7 +40,7 @@ object PythonDependencyParser extends XDependencyParser {
       }.collectAll[Literal]
         .to(Iterable)
 
-    findOriginalDeclaration(setupCall.reachableBy(dataSourcesToRequires))
+    findOriginalDeclaration(dataSourcesToRequires)
       .map(x => X2Cpg.stripQuotes(x.code))
       .map {
         case requirementsPattern(name, versionSpecifiers, _) if versionSpecifiers.contains("==") =>

--- a/src/test/scala/io/appthreat/atom/PythonDependencyScannerTests.scala
+++ b/src/test/scala/io/appthreat/atom/PythonDependencyScannerTests.scala
@@ -7,7 +7,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import java.io.File
 
-class PythonDependencyScannerTests extends PySrc2CpgFixture(withOssDataflow = true) {
+class PythonDependencyScannerTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
   "dependencies from the `requests` library" should {
     lazy val cpg = code(


### PR DESCRIPTION
* Added alternative to tracking the source for `install_requires` and simply scan AST, if data dependencies are present, then the data-flow engine is used
* Made generating data dependencies optional, with default being false in the config