### PR TITLE
Unroll Data-Flow Paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / organization := "io.appthreat"
 ThisBuild / version      := "1.0.0"
 ThisBuild / scalaVersion := "3.3.0"
 
-val joernVersion      = "2.0.8"
+val joernVersion      = "2.0.13"
 
 lazy val atom = Projects.atom
 

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -345,7 +345,7 @@ object Atom {
       }
       Right("Atom sliced successfully")
     } catch {
-      case err: Throwable if err.getMessage == null => Left(err.getStackTrace.mkString("\n"))
+      case err: Throwable if err.getMessage == null => Left(err.getStackTrace.take(7).mkString("\n"))
       case err: Throwable                           => Left(err.getMessage)
     }
   }

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -142,14 +142,6 @@ object Atom {
               case c: AtomDataFlowConfig => c.copy(mustEndAtExternalMethod = true)
               case _                     => c
             }
-          ),
-        opt[Unit]('u', "unroll-paths")
-          .text(s"unrolls the data-flow graph-style representation as a 'paths' attribute")
-          .action((_, c) =>
-            c match {
-              case c: AtomDataFlowConfig => c.copy(unrollPaths = true)
-              case _                     => c
-            }
           )
       )
     cmd("usages")
@@ -340,10 +332,7 @@ object Atom {
           val dataFlowSlice =
             Using.resource(loadFromOdb(outputAtomFile))(sliceCpg).collect { case x: DataFlowSlice => x }
           val atomDataFlowSliceJson =
-            config match
-              case x: AtomDataFlowConfig if x.unrollPaths =>
-                dataFlowSlice.map(x => AtomDataFlowSlice(x, DataFlowGraph.buildFromSlice(x).paths).toJson)
-              case _ => dataFlowSlice.map(x => AtomDataFlowSlice(x).toJson)
+            dataFlowSlice.map(x => AtomDataFlowSlice(x, DataFlowGraph.buildFromSlice(x).paths).toJson)
           saveSlice(config.outputSliceFile, atomDataFlowSliceJson)
         case _: UsagesConfig =>
           saveSlice(config.outputSliceFile, Using.resource(loadFromOdb(outputAtomFile))(sliceCpg).map(_.toJson))

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -345,7 +345,7 @@ object Atom {
       }
       Right("Atom sliced successfully")
     } catch {
-      case err: Throwable if err.getMessage == null => Left(err.getCause.toString)
+      case err: Throwable if err.getMessage == null => Left(err.getStackTrace.mkString("\n"))
       case err: Throwable                           => Left(err.getMessage)
     }
   }

--- a/src/main/scala/io/appthreat/atom/dataflows/DataFlowGraph.scala
+++ b/src/main/scala/io/appthreat/atom/dataflows/DataFlowGraph.scala
@@ -1,0 +1,62 @@
+package io.appthreat.atom.dataflows
+
+import io.joern.dataflowengineoss.slicing.{DataFlowSlice, SliceNode}
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+
+import scala.collection.mutable
+
+private class DataFlowGraph(nodes: Set[DFNode]) {
+
+  private type Path = List[Long]
+
+  def paths: Set[Path] = {
+    implicit val finalSet: mutable.Set[Path] = mutable.Set.empty
+    implicit val nMap: Map[Long, DFNode]     = nodes.map(x => x.id -> x).toMap
+    nodes.foreach { n =>
+      val currPath = List(n.id)
+      follow(currPath, n.out.flatMap(nMap.get))
+    }
+    finalSet.toSet
+  }
+
+  private def isSubList[A](short: List[A], long: List[A]): Boolean = {
+    val sLong  = long.to(LazyList)
+    val sShort = short.to(LazyList)
+    sLong.tails exists (_.startsWith(sShort))
+  }
+
+  private def isSubList[A](lst: List[A])(implicit finalSet: mutable.Set[Path]): Boolean =
+    finalSet.filterNot(_.size < lst.size).exists(xs => isSubList(lst, xs))
+
+  private def follow(currPath: List[Long], outNodes: Set[DFNode])(implicit
+    nMap: Map[Long, DFNode],
+    finalSet: mutable.Set[Path]
+  ): Unit = {
+    outNodes.foreach { x =>
+      val path = currPath :+ x.id
+      if (x.out.isEmpty && !isSubList(path)) {
+        finalSet.add(path)
+      } else {
+        follow(path, x.out.flatMap(nMap.get))
+      }
+    }
+  }
+
+}
+
+private case class DFNode(id: Long, in: Set[Long], out: Set[Long])
+
+object DataFlowGraph {
+
+  private def DF_EDGES = Set(EdgeTypes.REACHING_DEF, EdgeTypes.CALL)
+
+  def buildFromSlice(slice: DataFlowSlice): DataFlowGraph = {
+    val dfNodes = slice.nodes.map { n =>
+      val inEs  = slice.edges.filter(e => DF_EDGES.contains(e.label) && e.dst == n.id).map(_.src)
+      val outEs = slice.edges.filter(e => DF_EDGES.contains(e.label) && e.src == n.id).map(_.dst)
+      DFNode(n.id, inEs, outEs)
+    }
+    new DataFlowGraph(dfNodes)
+  }
+
+}

--- a/src/main/scala/io/appthreat/atom/dataflows/DataFlowGraph.scala
+++ b/src/main/scala/io/appthreat/atom/dataflows/DataFlowGraph.scala
@@ -32,12 +32,13 @@ private class DataFlowGraph(nodes: Set[DFNode]) {
     nMap: Map[Long, DFNode],
     finalSet: mutable.Set[Path]
   ): Unit = {
-    outNodes.filterNot(currPath.contains).foreach { x =>
-      val path = currPath :+ x.id
-      if (x.out.isEmpty && !isSubList(path)) {
-        finalSet.add(path)
+    outNodes.foreach { x =>
+      val path  = currPath :+ x.id
+      val queue = x.out.filterNot(currPath.contains)
+      if (queue.isEmpty) {
+        if (!isSubList(path)) finalSet.add(path)
       } else {
-        follow(path, x.out.flatMap(nMap.get))
+        follow(path, queue.flatMap(nMap.get))
       }
     }
   }

--- a/src/main/scala/io/appthreat/atom/dataflows/DataFlowGraph.scala
+++ b/src/main/scala/io/appthreat/atom/dataflows/DataFlowGraph.scala
@@ -32,7 +32,7 @@ private class DataFlowGraph(nodes: Set[DFNode]) {
     nMap: Map[Long, DFNode],
     finalSet: mutable.Set[Path]
   ): Unit = {
-    outNodes.foreach { x =>
+    outNodes.filterNot(currPath.contains).foreach { x =>
       val path = currPath :+ x.id
       if (x.out.isEmpty && !isSubList(path)) {
         finalSet.add(path)

--- a/src/main/scala/io/appthreat/atom/package.scala
+++ b/src/main/scala/io/appthreat/atom/package.scala
@@ -43,8 +43,7 @@ package object atom {
   case class AtomDataFlowConfig(
     sinkPatternFilter: Option[String] = None,
     mustEndAtExternalMethod: Boolean = false,
-    sliceDepth: Int = DEFAULT_SLICE_DEPTH,
-    unrollPaths: Boolean = false
+    sliceDepth: Int = DEFAULT_SLICE_DEPTH
   ) extends AtomConfig
 
   case class AtomUsagesConfig(

--- a/src/main/scala/io/appthreat/atom/package.scala
+++ b/src/main/scala/io/appthreat/atom/package.scala
@@ -2,6 +2,7 @@ package io.appthreat
 
 import better.files.File
 import io.appthreat.atom.Atom.*
+import io.circe.{Encoder, Json}
 import io.joern.dataflowengineoss.slicing.*
 
 package object atom {
@@ -42,7 +43,8 @@ package object atom {
   case class AtomDataFlowConfig(
     sinkPatternFilter: Option[String] = None,
     mustEndAtExternalMethod: Boolean = false,
-    sliceDepth: Int = DEFAULT_SLICE_DEPTH
+    sliceDepth: Int = DEFAULT_SLICE_DEPTH,
+    unrollPaths: Boolean = false
   ) extends AtomConfig
 
   case class AtomUsagesConfig(
@@ -50,5 +52,20 @@ package object atom {
     excludeOperatorCalls: Boolean = true,
     includeMethodSource: Boolean = false
   ) extends AtomConfig
+
+  import io.joern.dataflowengineoss.slicing._
+  import io.circe.generic.auto._
+  import io.circe.syntax.EncoderOps
+
+  implicit val encodeDataFlowSlice: Encoder[AtomDataFlowSlice] = Encoder.instance {
+    case AtomDataFlowSlice(dataFlowSlice, paths) =>
+      Json.obj("graph" -> dataFlowSlice.asJson, "paths" -> paths.asJson)
+  }
+
+  case class AtomDataFlowSlice(graph: DataFlowSlice, paths: Set[List[Long]] = Set.empty) {
+
+    def toJson: String = this.asJson.toString()
+
+  }
 
 }


### PR DESCRIPTION
* Wrapped the data-flow path slice with an "AtomDataFlowSlice"
* Added unroll option to run a DFS to generate all the paths of the data-flow slice
* Deduplicate sub-paths so that all paths that are displayed are the both unique and not subpaths of one another
* Upgraded Joern to 2.0.13