### PR TITLE
Python data flow tuning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / organization := "io.appthreat"
 ThisBuild / version      := "1.0.0"
 ThisBuild / scalaVersion := "3.3.0"
 
-val joernVersion      = "2.0.25"
+val joernVersion      = "2.0.46"
 
 lazy val atom = Projects.atom
 

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -39,6 +39,7 @@ object Atom {
   val DEFAULT_SLICE_OUT_FILE        = "slices.json"
   val DEFAULT_SLICE_DEPTH           = 7
   val DEFAULT_MAX_DEFS: Int         = 2000
+  val TYPE_PROPAGATION_ITERATIONS   = 1
   private val MAVEN_JAR_PATH: File  = File.home / ".m2"
   private val GRADLE_JAR_PATH: File = File.home / ".gradle" / "caches" / "modules-2" / "files-2.1"
   private val SBT_JAR_PATH: File    = File.home / ".ivy2" / "cache"
@@ -302,7 +303,9 @@ object Atom {
       case Languages.JSSRC | Languages.JAVASCRIPT | "JS" | "TS" | "TYPESCRIPT" =>
         new JsSrc2Cpg()
           .createCpgWithOverlays(
-            JSConfig(disableDummyTypes = true)
+            JSConfig()
+              .withDisableDummyTypes(true)
+              .withTypePropagationIterations(TYPE_PROPAGATION_ITERATIONS)
               .withInputPath(config.inputPath.pathAsString)
               .withOutputPath(outputAtomFile)
           )
@@ -318,7 +321,9 @@ object Atom {
       case Languages.PYTHONSRC | Languages.PYTHON | "PY" =>
         new Py2CpgOnFileSystem()
           .createCpgWithOverlays(
-            PyConfig(disableDummyTypes = true)
+            PyConfig()
+              .withDisableDummyTypes(true)
+              .withTypePropagationIterations(TYPE_PROPAGATION_ITERATIONS)
               .withInputPath(config.inputPath.pathAsString)
               .withOutputPath(outputAtomFile)
               .withDefaultIgnoredFilesRegex(List("\\..*".r))

--- a/wrapper/nodejs/astgen.js
+++ b/wrapper/nodejs/astgen.js
@@ -15,7 +15,7 @@ import {
 } from "fs";
 import { getAllFiles } from "./utils.mjs";
 
-const ASTGEN_VERSION = "3.1.0";
+const ASTGEN_VERSION = "3.2.0";
 
 const babelParserOptions = {
   sourceType: "unambiguous",

--- a/wrapper/nodejs/index.js
+++ b/wrapper/nodejs/index.js
@@ -13,17 +13,17 @@ if (!url.startsWith("file://")) {
 }
 const dirName = import.meta ? dirname(fileURLToPath(url)) : __dirname;
 
-const LOG4J_CONFIG = join(dirName, "plugins", "log4j2.xml");
-const ATOM_HOME = join(dirName, "plugins", "atom-1.0.0");
-const APP_LIB_DIR = join(ATOM_HOME, "lib");
+export const LOG4J_CONFIG = join(dirName, "plugins", "log4j2.xml");
+export const ATOM_HOME = join(dirName, "plugins", "atom-1.0.0");
+export const APP_LIB_DIR = join(ATOM_HOME, "lib");
 const freeMemoryGB = Math.max(Math.floor(freemem() / 1024 / 1024 / 1024), 4);
-const JVM_ARGS =
+export const JVM_ARGS =
   "-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1";
-const JAVA_OPTS = `${process.env.JAVA_OPTS || ""} -Xms${Math.round(
+export const JAVA_OPTS = `${process.env.JAVA_OPTS || ""} -Xms${Math.round(
   Math.floor(freeMemoryGB / 2)
 )}G -Xmx${freeMemoryGB}G ${JVM_ARGS}`;
-const APP_MAIN_CLASS = "io.appthreat.atom.Atom";
-const APP_CLASSPATH = join(
+export const APP_MAIN_CLASS = "io.appthreat.atom.Atom";
+export const APP_CLASSPATH = join(
   APP_LIB_DIR,
   "io.appthreat.atom-1.0.0-classpath.jar"
 );
@@ -35,7 +35,7 @@ if (process.env.JAVA_HOME) {
 const atomLibs = [APP_CLASSPATH];
 const argv = process.argv.slice(2);
 
-const executeAtom = (atomArgs) => {
+export const executeAtom = (atomArgs) => {
   if (!detectJava()) {
     // If we couldn't detect java but there is a JAVA_HOME defined then
     // try fixing the PATH manually. Usually required for windows users

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.22.5",

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",


### PR DESCRIPTION
Update joern to 2.0.46, which has fixes for the Python dataflow memory bug
Limit type recovery iteration count to 1

@cerrussell, Could you create atom samples for Python and js using this branch and let me know if you see any difference in the slice data and performance?