### PR TITLE
Set default delombok mode to types only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "1.7.3"
+ThisBuild / version      := "1.7.4"
 ThisBuild / scalaVersion := "3.3.1"
 
-val chenVersion      = "1.0.8"
+val chenVersion      = "1.0.9"
 
 lazy val atom = Projects.atom
 

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -44,13 +44,16 @@ object Atom:
     val DEFAULT_ATOM_OUT_FILE: String =
         if Properties.isWin || Charset.defaultCharset() != Charset.forName("UTF-8") then "app.atom"
         else "app.⚛"
-    val DEFAULT_SLICE_OUT_FILE              = "slices.json"
-    val DEFAULT_SLICE_DEPTH                 = 7
-    val DEFAULT_MAX_DEFS: Int               = 2000
-    val FRAMEWORK_INPUT_TAG: String         = "framework-input"
-    val FRAMEWORK_OUTPUT_TAG: String        = "framework-output"
-    val DEFAULT_EXPORT_DIR: String          = "atom-exports"
-    val DEFAULT_EXPORT_FORMAT: String       = "graphml"
+    val DEFAULT_SLICE_OUT_FILE        = "slices.json"
+    val DEFAULT_SLICE_DEPTH           = 7
+    val DEFAULT_MAX_DEFS: Int         = 2000
+    val FRAMEWORK_INPUT_TAG: String   = "framework-input"
+    val FRAMEWORK_OUTPUT_TAG: String  = "framework-output"
+    val DEFAULT_EXPORT_DIR: String    = "atom-exports"
+    val DEFAULT_EXPORT_FORMAT: String = "graphml"
+    // Possible values: no-delombok, default, types-only, run-delombok
+    private val DEFAULT_DELOMBOK_MODE: String =
+        sys.env.getOrElse("CHEN_DELOMBOK_MODE", "types-only")
     private val TYPE_PROPAGATION_ITERATIONS = 1
     private val MAVEN_JAR_PATH: File        = File.home / ".m2" / "repository"
     private val GRADLE_JAR_PATH: File = File.home / ".gradle" / "caches" / "modules-2" / "files-2.1"
@@ -448,7 +451,8 @@ object Atom:
                             JavaConfig(
                               fetchDependencies = true,
                               inferenceJarPaths = JAR_INFERENCE_PATHS,
-                              enableTypeRecovery = true
+                              enableTypeRecovery = true,
+                              delombokMode = Some(DEFAULT_DELOMBOK_MODE)
                             )
                                 .withInputPath(config.inputPath.pathAsString)
                                 .withDefaultIgnoredFilesRegex(

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.23.6",

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",


### PR DESCRIPTION
Related ticket: https://github.com/CycloneDX/cdxgen/issues/780

This way the original annotations get preserved and becomes available via usages slicing.