### PR TITLE
Use java version of atom in the image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.2"
+ThisBuild / version      := "2.0.3"
 ThisBuild / scalaVersion := "3.3.1"
 
 val chenVersion      = "2.0.2"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -24,7 +24,7 @@ ENV JAVA_VERSION=$JAVA_VERSION \
     PHP_PARSER_BIN=/opt/vendor/bin/php-parse \
     COMPOSER_ALLOW_SUPERUSER=1
 
-ENV PATH=${PATH}:/opt/bin:/opt/vendor/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:/usr/local/bin/:/root/.local/bin:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:
+ENV PATH=/opt/bin:/opt/vendor/bin:${PATH}:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:/usr/local/bin/:/root/.local/bin:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:
 
 WORKDIR /opt
 
@@ -76,7 +76,7 @@ RUN unzip -q atom.zip \
     && composer update --no-progress --prefer-dist --ignore-platform-reqs \
     && cd /opt/nodejs && npm install --only=production && cd /opt \
     && sudo npm install -g /opt/nodejs \
-    && rm -rf atom.zip composer.json composer.lock composer-setup.php \
+    && rm -rf atom.zip composer.json composer.lock composer-setup.php /usr/local/bin/atom \
     && /opt/bin/atom --help \
     && which astgen \
     && which phpastgen \

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.23.6",

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",


### PR DESCRIPTION
Noticed that the node version was getting installed in /usr/local/bin, which was getting executed instead of the performant java version.

Related: #114 