### PR TITLE
Improves local module name detection by looking for __init__.py

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.13"
+ThisBuild / version      := "2.0.14"
 ThisBuild / scalaVersion := "3.4.1"
 
 val chenVersion      = "2.0.11"
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "io.appthreat"      %% "semanticcpg"       % Versions.chen % Test classifier "tests",
   "io.appthreat"      %% "x2cpg"             % Versions.chen % Test classifier "tests",
   "io.appthreat"      %% "pysrc2cpg"         % Versions.chen % Test classifier "tests",
-  "org.scalatest"     %% "scalatest"         % "3.2.18"       % Test
+  "org.scalatest"     %% "scalatest"         % "3.2.19"       % Test
 )
 
 Compile / doc / scalacOptions ++= Seq("-doc-title", "atom apidocs", "-doc-version", version.value)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="appthreat" \
       org.opencontainers.image.description="Container image for AppThreat atom" \
       org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -v $HOME:$HOME -v $(pwd):/app:rw -it ghcr.io/appthreat/atom atom -o /app/app.atom -l java /app"
 
-ARG MAVEN_VERSION=3.9.6
+ARG MAVEN_VERSION=3.9.8
 
 ENV MAVEN_VERSION=$MAVEN_VERSION \
     MAVEN_HOME="/opt/maven/${MAVEN_VERSION}" \

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "typescript": "^5.4.5",
+        "typescript": "^5.5.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to https://github.com/CycloneDX/cdxgen/issues/1171

Prior to this PR, local module names were determined only based on the root folder names. This led to parsedeps command over-reporting many local modules. With this PR, local module name detection is improved by filtering modules based on:

- \_\_init\_\_.py files
- Local file names

Attached deps slices file is looking much cleaner listing only the external libraries for numpy 2.0.0

[deps.slices.json.txt](https://github.com/user-attachments/files/15975510/deps.slices.json.txt)
