### PR TITLE
Update chen to get memory and performance improvements

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21.x'
+          node-version: '22.x'
       - name: Delete `.rustup` directory
         run: rm -rf /home/runner/.rustup # to save disk space
         if: runner.os == 'Linux'

--- a/.github/workflows/nodejstests.yml
+++ b/.github/workflows/nodejstests.yml
@@ -57,7 +57,7 @@ jobs:
         if: runner.os == 'macOS'
       - name: Install ubuntu packages
         run: |
-          sudo apt install zlibc php-zip
+          sudo apt install zlib1g php-zip
         if: runner.os == 'Linux'
       - run: |
           sbt stage assembly createDistribution

--- a/.github/workflows/nodejstests.yml
+++ b/.github/workflows/nodejstests.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         java-version: ['21', '22']
-        node-version: ['21.x']
+        node-version: ['20.x', '22.x']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         java-version: ['21', '22']
-        node-version: ['21.x']
+        node-version: ['22.x']
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/nodejstests.yml
+++ b/.github/workflows/nodejstests.yml
@@ -57,7 +57,8 @@ jobs:
         if: runner.os == 'macOS'
       - name: Install ubuntu packages
         run: |
-          sudo apt install zlib1g php-zip
+          sudo apt update -y
+          sudo apt install -y zlib1g php-zip
         if: runner.os == 'Linux'
       - run: |
           sbt stage assembly createDistribution

--- a/.github/workflows/nodejstests.yml
+++ b/.github/workflows/nodejstests.yml
@@ -57,7 +57,7 @@ jobs:
         if: runner.os == 'macOS'
       - name: Install ubuntu packages
         run: |
-          apt install zlibc php-zip
+          sudo apt install zlibc php-zip
         if: runner.os == 'Linux'
       - run: |
           sbt stage assembly createDistribution

--- a/.github/workflows/nodejstests.yml
+++ b/.github/workflows/nodejstests.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Install sbt
         run: brew install sbt
         if: runner.os == 'macOS'
+      - name: Install ubuntu packages
+        run: |
+          apt install zlibc php-zip
+        if: runner.os == 'Linux'
       - run: |
           sbt stage assembly createDistribution
           cd wrapper/nodejs

--- a/.github/workflows/nodejstests.yml
+++ b/.github/workflows/nodejstests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install sbt
         run: brew install sbt
         if: runner.os == 'macOS'

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -27,7 +27,8 @@ jobs:
         java-version: '21'
     - name: Release
       run: |
-        sudo apt install zlib1g php-zip
+        sudo apt update -y
+        sudo apt install -y zlib1g php-zip
         sbt scalafmtCheck stage assembly createDistribution
         sha512sum target/atom.zip > target/atom.zip.sha512
         npm config set //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -27,6 +27,7 @@ jobs:
         java-version: '21'
     - name: Release
       run: |
+        sudo apt install zlib1g php-zip
         sbt scalafmtCheck stage assembly createDistribution
         sha512sum target/atom.zip > target/atom.zip.sha512
         npm config set //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -82,6 +82,10 @@ jobs:
       - run: |
           sbt stage astGenDlTask
           python -m pip install atom-tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
+      - run: |
           ./atom.sh --remove-atom -o /tmp/java.atom -l java $GITHUB_WORKSPACE/repotests/shiftleft-java-example -Dlog4j.configurationFile=log4j2.xml
           ./atom.sh --remove-atom -o /tmp/juice.atom -l js $GITHUB_WORKSPACE/repotests/juice-shop -Dlog4j.configurationFile=log4j2.xml
           ./atom.sh --remove-atom -o /tmp/ts.atom -l js $GITHUB_WORKSPACE/repotests/shiftleft-ts-example -Dlog4j.configurationFile=log4j2.xml
@@ -105,10 +109,17 @@ jobs:
           ./atom.sh usages --remove-atom -o /tmp/c3.atom -l c $GITHUB_WORKSPACE/repotests/libexpat -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/c.usages.json
 
           ./atom.sh --remove-atom -o /tmp/java-sec-code.atom -l java $GITHUB_WORKSPACE/repotests/java-sec-code -Dlog4j.configurationFile=log4j2.xml -x --export-dir gml_exports
+        if: runner.os != 'Windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
-        shell: bash
+      - run: |
+          .\atom.bat usages --extract-endpoints --remove-atom -o $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py3.atom -l python $GITHUB_WORKSPACE\\repotests\\DjanGoat -Dlog4j.configurationFile=log4j2.xml --slice-outfile $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py.usages.json
+          python -m json.tool $GITHUB_WORKSPACE\\repotests\\DjanGoat\\openapi.generated.json
+        if: runner.os == 'Windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
       - run: |
           npm install -g @cyclonedx/cdxgen --omit=optional
           cdxgen -t java --deep -o $GITHUB_WORKSPACE/repotests/bouncycastle-examples/bom.json $GITHUB_WORKSPACE/repotests/bouncycastle-examples

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: '21.x'
+          node-version: '22.x'
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -114,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
       - run: |
-          .\atom.bat usages --extract-endpoints --remove-atom -o $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py3.atom -l python $GITHUB_WORKSPACE\\repotests\\DjanGoat -Dlog4j.configurationFile=log4j2.xml --slice-outfile $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py.usages.json
+          .\atom.bat usages --extract-endpoints --remove-atom -o $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py3.atom -l python $GITHUB_WORKSPACE\\repotests\\DjanGoat --slice-outfile $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py.usages.json
           python -m json.tool $GITHUB_WORKSPACE\\repotests\\DjanGoat\\openapi.generated.json
         if: runner.os == 'Windows'
         env:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -108,6 +108,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
+        shell: bash
       - run: |
           npm install -g @cyclonedx/cdxgen --omit=optional
           cdxgen -t java --deep -o $GITHUB_WORKSPACE/repotests/bouncycastle-examples/bom.json $GITHUB_WORKSPACE/repotests/bouncycastle-examples

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -75,12 +75,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install sbt
         run: brew install sbt
         if: runner.os == 'macOS'
       - run: |
           sbt stage astGenDlTask
+          python -m pip install atom-tools
           ./atom.sh --remove-atom -o /tmp/java.atom -l java $GITHUB_WORKSPACE/repotests/shiftleft-java-example -Dlog4j.configurationFile=log4j2.xml
           ./atom.sh --remove-atom -o /tmp/juice.atom -l js $GITHUB_WORKSPACE/repotests/juice-shop -Dlog4j.configurationFile=log4j2.xml
           ./atom.sh --remove-atom -o /tmp/ts.atom -l js $GITHUB_WORKSPACE/repotests/shiftleft-ts-example -Dlog4j.configurationFile=log4j2.xml
@@ -98,7 +99,8 @@ jobs:
           ./atom.sh usages --remove-atom -o /tmp/java3.atom -l java $GITHUB_WORKSPACE/repotests/shiftleft-java-example -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/java.usages.json
           # ./atom.sh usages --remove-atom -o /tmp/juice3.atom -l js $GITHUB_WORKSPACE/repotests/juice-shop -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/juice.usages.json
           ./atom.sh usages --remove-atom -o /tmp/ts3.atom -l js $GITHUB_WORKSPACE/repotests/shiftleft-ts-example -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/ts.usages.json
-          ./atom.sh usages --remove-atom -o /tmp/py3.atom -l python $GITHUB_WORKSPACE/repotests/DjanGoat -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/py.usages.json
+          ./atom.sh usages --extract-endpoints --remove-atom -o /tmp/py3.atom -l python $GITHUB_WORKSPACE/repotests/DjanGoat -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/py.usages.json
+          python -m json.tool $GITHUB_WORKSPACE/repotests/DjanGoat/openapi.generated.json
           ./atom.sh usages --remove-atom -o /tmp/py4.atom -l python $GITHUB_WORKSPACE/repotests/django-DefectDojo -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/py4.usages.json
           ./atom.sh usages --remove-atom -o /tmp/c3.atom -l c $GITHUB_WORKSPACE/repotests/libexpat -Dlog4j.configurationFile=log4j2.xml --slice-outfile /tmp/c.usages.json
 

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -114,8 +114,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
       - run: |
-          .\atom.bat usages --extract-endpoints --remove-atom -o $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py3.atom -l python $GITHUB_WORKSPACE\\repotests\\DjanGoat --slice-outfile $GITHUB_WORKSPACE\\repotests\\DjanGoat\\py.usages.json
-          python -m json.tool $GITHUB_WORKSPACE\\repotests\\DjanGoat\\openapi.generated.json
+          .\atom.bat usages --extract-endpoints --remove-atom -o $env:GITHUB_WORKSPACE\\repotests\\DjanGoat\\py3.atom -l python $env:GITHUB_WORKSPACE\\repotests\\DjanGoat --slice-outfile $env:GITHUB_WORKSPACE\\repotests\\DjanGoat\\py.usages.json
+          python -m json.tool $env:GITHUB_WORKSPACE\\repotests\\DjanGoat\\openapi.generated.json
         if: runner.os == 'Windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.15"
+ThisBuild / version      := "2.0.16"
 ThisBuild / scalaVersion := "3.4.1"
 
-val chenVersion      = "2.0.11"
+val chenVersion      = "2.1.1"
 
 lazy val atom = Projects.atom
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / organization := "io.appthreat"
 ThisBuild / version      := "2.0.16"
 ThisBuild / scalaVersion := "3.4.1"
 
-val chenVersion      = "2.1.1"
+val chenVersion      = "2.1.2"
 
 lazy val atom = Projects.atom
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -41,10 +41,11 @@ RUN set -e; \
     esac; \
     echo -e "[nodejs]\nname=nodejs\nstream=20\nprofiles=\nstate=enabled\n" > /etc/dnf/modules.d/nodejs.module \
     && microdnf install -y gcc git-core php php-cli php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make \
-        python3.11 python3.11-devel python3.11-pip \
+        python3.12 python3.12-devel python3.12-pip \
         wget bash glibc-common glibc-all-langpacks java-21-openjdk-headless \
         pcre2 findutils which tar gzip zip unzip sudo nodejs \
-    && alternatives --install /usr/bin/python3 python /usr/bin/python3.11 1 \
+    && alternatives --install /usr/bin/python3 python /usr/bin/python3.12 10 \
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 10 \
     && python3 --version \
     && node --version \
     && python3 -m pip install --upgrade pip poetry atom-tools \

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,3 +1,3 @@
 org.eclipse.cdt jars were downloaded from
 
-https://download.eclipse.org/tools/cdt/releases/11.5/cdt-11.5.0/plugins/
+https://download.eclipse.org/tools/cdt/releases/11.6/cdt-11.6.1/plugins/

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "typescript": "^5.5.2",
+        "typescript": "^5.5.3",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.7",
-    "typescript": "^5.5.2",
+    "typescript": "^5.5.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
@cerrussell Can you check this branch with atom-tools to ensure we don't lose any endpoints especially for python?

To install the atom command based on this branch.

```shell
git clone https://github.com/AppThreat/atom.git
cd atom
git checkout feature/chen-update-mem-perf
export GITHUB_TOKEN=PAT with read access
sbt clean stage scalafmt test createDistribution
cd wrapper/nodejs
bash build.sh && sudo npm install -g .
```
