### PR TITLE
update chen to get cpg 1.0.1 and the latest protobuf

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '22.x'
+        node-version: '23.x'
         registry-url: https://registry.npmjs.org/
     - uses: coursier/cache-action@v6
     - name: Set up JDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             target/graalvm-native-image/atom.exe
@@ -110,7 +110,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             bom.json

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.22"
+ThisBuild / version      := "2.0.23"
 ThisBuild / scalaVersion := "3.5.2"
 
-val chenVersion = "2.2.1"
+val chenVersion = "2.2.2"
 
 lazy val atom = Projects.atom
 
@@ -31,7 +31,9 @@ libraryDependencies ++= Seq(
 
 excludeDependencies ++= Seq(
   ExclusionRule("dev.scalapy", "scalapy-core"),
-  ExclusionRule("org.scala-lang", "scala3-compiler")
+  ExclusionRule("org.scala-lang", "scala3-compiler"),
+  ExclusionRule("commons-io", "commons-io"),
+  ExclusionRule("com.google.protobuf", "protobuf-java-util")
 )
 
 Compile / doc / scalacOptions ++= Seq("-doc-title", "atom apidocs", "-doc-version", version.value)

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.0.22",
+      "version": "2.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.26.2",

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",


### PR DESCRIPTION
Also exclude `commons-io` and `protobuf-java-util`, since atom doesn't depend on those packages.