### PR TITLE
Update chen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ libraryDependencies ++= Seq(
 excludeDependencies ++= Seq(
   ExclusionRule("dev.scalapy", "scalapy-core"),
   ExclusionRule("org.scala-lang", "scala3-compiler"),
-  ExclusionRule("commons-io", "commons-io"),
   ExclusionRule("com.google.protobuf", "protobuf-java-util"),
   ExclusionRule("com.github.tototoshi", "scala-csv_3"),
   ExclusionRule("au.com.bytecode", "opencsv")

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.24"
+ThisBuild / version      := "2.0.25"
 ThisBuild / scalaVersion := "3.5.2"
 
-val chenVersion = "2.2.2"
+val chenVersion = "2.2.3"
 
 lazy val atom = Projects.atom
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.26.2",

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",


### PR DESCRIPTION
This brings tagging improvements (reuse component tags) and soot 4.6.0, which improves android apk support. In addition, it restores the dependency on `commons-io`, which is needed for apk parsing.