### PR TITLE
Support for Atom Ruby Home env variable

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,8 +1,6 @@
-name: Upload Container image
+name: Upload Container images
 
 on:
-  schedule:
-  - cron: "0 8 * * *"
   push:
     branches:
       - main
@@ -18,7 +16,7 @@ env:
   IMAGE_NAME: appthreat/atom
 
 jobs:
-  deploy:
+  al9-deploy:
     if: github.repository_owner == 'appthreat'
     runs-on: ubuntu-24.04
     permissions:
@@ -80,6 +78,52 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=atom
           cache-to: type=gha,mode=max,scope=atom
+
+  sle-deploy:
+    if: github.repository_owner == 'appthreat'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '22'
+      - uses: sbt/setup-sbt@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23.x'
+      - name: Delete `.rustup` directory
+        run: rm -rf /home/runner/.rustup # to save disk space
+        if: runner.os == 'Linux'
+      - name: Delete `.cargo` directory # to save disk space
+        run: rm -rf /home/runner/.cargo
+        if: runner.os == 'Linux'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.coursier
+          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
+      - run: |
+          sbt stage createDistribution
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta2

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.1.0"
+ThisBuild / version      := "2.1.1"
 ThisBuild / scalaVersion := "3.6.2"
 
 val chenVersion = "2.3.0"

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/index.js
+++ b/wrapper/nodejs/index.js
@@ -43,15 +43,13 @@ export const executeAtom = (atomArgs) => {
   if (!detectJava()) {
     // If we couldn't detect java but there is a JAVA_HOME defined then
     // try fixing the PATH manually. Usually required for windows users
-    if (process.env.JAVA_HOME) {
+    const atomJavaHome = process.env.ATOM_JAVA_HOME || process.env.JAVA_HOME;
+    if (atomJavaHome) {
       process.env.PATH =
-        process.env.PATH +
-        delimiter +
-        join(process.env.JAVA_HOME, "bin") +
-        delimiter;
+        join(atomJavaHome, "bin") + delimiter + process.env.PATH + delimiter;
     } else {
       console.warn(
-        "A Java JDK is not installed or can't be found. Please install JDK version 17 or higher before running atom."
+        "A Java JDK is not installed or can't be found. Please install JDK version 21 or higher before running atom."
       );
       return false;
     }

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.26.3",

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",

--- a/wrapper/nodejs/rbastgen.js
+++ b/wrapper/nodejs/rbastgen.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, delimiter } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { detectRuby } from "./utils.mjs";
@@ -25,12 +26,24 @@ function main(argvs) {
     0,
     process.env.RUBY_ASTGEN_BIN || join(PLUGINS_HOME, "bin", "ruby_ast_gen")
   );
+  const env = {
+    ...process.env
+  };
+  if (
+    process.env.ATOM_RUBY_HOME &&
+    existsSync(join(process.env.ATOM_RUBY_HOME, "bin"))
+  ) {
+    const rubyBinDir = join(process.env.ATOM_RUBY_HOME, "bin");
+    if (!env.PATH.includes(rubyBinDir)) {
+      env.PATH = `${rubyBinDir}${delimiter}${env.PATH}`;
+    }
+  }
   spawnSync(process.env.RUBY_CMD || "ruby", argvs, {
     encoding: "utf-8",
     cwd,
     stdio: "inherit",
     stderr: "inherit",
-    env: process.env,
+    env,
     timeout: process.env.ATOM_TIMEOUT || process.env.ASTGEN_TIMEOUT
   });
 }


### PR DESCRIPTION
Our Ruby AST gen requires, Ruby >= 3.4.0

For situations, where the Ruby version requirements for the application is different, the caller could set the environment variable ATOM_RUBY_HOME pointing to 3.4.x.