### PR TITLE
Increase character limit for ruby code capture.

### DIFF
--- a/wrapper/nodejs/plugins/rubyastgen/Gemfile
+++ b/wrapper/nodejs/plugins/rubyastgen/Gemfile
@@ -5,7 +5,7 @@ ruby ">=3.4.1"
 source "https://rubygems.org"
 
 group :frontend do
-    gem "ruby_ast_gen", github: 'joernio/ruby_ast_gen', ref: 'v0.34.0'
+    gem "ruby_ast_gen", github: 'appthreat/ruby_ast_gen', ref: 'v0.34.1'
     gem "parser"
     gem "ostruct"
 end

--- a/wrapper/nodejs/plugins/rubyastgen/Gemfile.lock
+++ b/wrapper/nodejs/plugins/rubyastgen/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/joernio/ruby_ast_gen.git
-  revision: 1c6e88faec50a986d319e7fbcfe297ec01c48e5a
-  ref: v0.34.0
+  remote: https://github.com/appthreat/ruby_ast_gen.git
+  revision: df21eaeb39f962c41946ec4391ff20080e4d8218
+  ref: v0.34.1
   specs:
     ruby_ast_gen (0.34.0)
 
@@ -17,6 +17,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
   x86_64-darwin-23
 
 DEPENDENCIES


### PR DESCRIPTION
Uses the AppThreat/ruby_ast_gen fork so that we can capture enough code for endpoint detection.