### PR TITLE
Use the correct ignore files regex method for the java frontend

### DIFF
--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -508,12 +508,8 @@ object Atom:
                       delombokMode = Some(DEFAULT_DELOMBOK_MODE)
                     )
                         .withInputPath(config.inputPath.pathAsString)
-                        .withDefaultIgnoredFilesRegex(
-                          List(
-                            "\\..*".r,
-                            ".*build/(generated|intermediates|outputs|tmp).*" r,
-                            ".*src/test.*" r
-                          )
+                        .withIgnoredFilesRegex(
+                          ".*(target|build)/(generated|intermediates|outputs|tmp).*"
                         )
                         .withOutputPath(outputAtomFile)
                   )


### PR DESCRIPTION
`withDefaultIgnoredFilesRegex` doesn't really work with the java frontend due to this [line](https://github.com/AppThreat/chen/blob/1a9078266f2bd2a61d4b46a4eb0947d61c0ad50d/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/util/SourceParser.scala#L96).

```scala
ignoredDefaultRegex = Option(JavaSrc2Cpg.DefaultIgnoredFilesRegex),
ignoredFilesRegex = Option(config.ignoredFilesRegex),
ignoredFilesPath = Option(config.ignoredFiles)
```

Switching to `withIgnoredFilesRegex` helps fix the issue [reported](https://github.com/CycloneDX/cdxgen/issues/1670#issuecomment-2697454795) in cdxgen.