### PR TITLE
Improved deterministic slices by making some queries default

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,16 +227,26 @@ atom -o app.atom -l java --export-atom --export-dir <export dir> --with-data-dep
 
 ## Environment variables
 
-| Variable                      | Description                                                                                   |
-| ----------------------------- | --------------------------------------------------------------------------------------------- |
-| **CHEN_IGNORE_TEST_DIRS**     | Set to true to ignore `test` directories. Only supported for Python for now.                  |
-| **CHEN_PYTHON_IGNORE_DIRS**   | Comma-separated list of directories to ignore for Python.                                     |
-| **CHEN_DELOMBOK_MODE**        | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`). |
-| **CHEN_INCLUDE_PATH**         | Include directories for the C frontend. Separate paths with `:` or `;`.                       |
-| **ATOM_TOOLS_OPENAPI_FORMAT** | OpenAPI format for atom-tools. Default: `openapi3.1.0`; alternative: `openapi3.0.1`.          |
-| **ATOM_TOOLS_WORK_DIR**       | Working directory for atom-tools. Defaults to atom input path.                                |
-| **ATOM_SCALASEM_WORK_DIR**    | Working directory for scalasem. Defaults to atom input path.                                  |
-| **ATOM_SCALASEM_SLICES_FILE** | Slices file name. Defaults to `semantics.slices.json`.                                        |
+| Variable                       | Description                                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| **CHEN_IGNORE_TEST_DIRS**      | Set to true to ignore `test` directories. Only supported for Python for now.                        |
+| **CHEN_PYTHON_IGNORE_DIRS**    | Comma-separated list of directories to ignore for Python.                                           |
+| **CHEN_DELOMBOK_MODE**         | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`).       |
+| **CHEN_INCLUDE_PATH**          | Include directories for the C frontend. Separate paths with `:` or `;`.                             |
+| **ATOM_TOOLS_OPENAPI_FORMAT**  | OpenAPI format for atom-tools. Default: `openapi3.1.0`; alternative: `openapi3.0.1`.                |
+| **ATOM_TOOLS_WORK_DIR**        | Working directory for atom-tools. Defaults to atom input path.                                      |
+| **ATOM_SCALASEM_WORK_DIR**     | Working directory for scalasem. Defaults to atom input path.                                        |
+| **ATOM_SCALASEM_SLICES_FILE**  | Slices file name. Defaults to `semantics.slices.json`.                                              |
+| **ATOM_JVM_ARGS**              | Overrides the JVM arguments, including heap memory values, constructed by the atom Node.js wrapper. |
+| **ATOM_JAVA_HOME**             | Java 21 or above to be used by atom.                                                                |
+| **PHP_CMD**                    | Overrides the PHP command used by the PHP frontend.                                                 |
+| **PHP_PARSER_BIN**             | Overrides the php-parse command used by the PHP frontend.                                           |
+| **SCALA_CMD**                  | Overrides the scala command.                                                                        |
+| **SCALAC_CMD**                 | Overrides the scalac command used by the scala frontend.                                            |
+| **ASTGEN_IGNORE_DIRS**         | Comma-separated list of directories to ignore by the JavaScript astgen pre-processor command.       |
+| **ASTGEN_IGNORE_FILE_PATTERN** | File pattern to ignore by the JavaScript astgen pre-processor command.                              |
+| **JAVA_CMD**                   | Overrides the java command.                                                                         |
+| **RUBY_CMD**                   | Overrides the Ruby command.                                                                         |
 
 ## Atom Specification
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,19 @@ atom -o app.atom -l java --export-atom --export-dir <export dir> --with-data-dep
 - Ruby (Requires Ruby 3.4.3. Supports Ruby 1.8 - 3.3 syntax)
 - Scala (WIP)
 
+## Environment variables
+
+| Variable                      | Description                                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| **CHEN_IGNORE_TEST_DIRS**     | Set to true to ignore `test` directories. Only supported for Python for now.                  |
+| **CHEN_PYTHON_IGNORE_DIRS**   | Comma-separated list of directories to ignore for Python.                                     |
+| **CHEN_DELOMBOK_MODE**        | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`). |
+| **CHEN_INCLUDE_PATH**         | Include directories for the C frontend. Separate paths with `:` or `;`.                       |
+| **ATOM_TOOLS_OPENAPI_FORMAT** | OpenAPI format for atom-tools. Default: `openapi3.1.0`; alternative: `openapi3.0.1`.          |
+| **ATOM_TOOLS_WORK_DIR**       | Working directory for atom-tools. Defaults to atom input path.                                |
+| **ATOM_SCALASEM_WORK_DIR**    | Working directory for scalasem. Defaults to atom input path.                                  |
+| **ATOM_SCALASEM_SLICES_FILE** | Slices file name. Defaults to `semantics.slices.json`.                                        |
+
 ## Atom Specification
 
 The intermediate representation used by atom is available under the same open-source license (Apache-2.0). The specification is available in [protobuf](./specification/atom.proto), [markdown](./specification/docs/spec.md), and [html](./specification/docs/spec.html) formats.
@@ -255,11 +268,6 @@ atom_struct = atom.CpgStruct(node=[method])
 with ZipFile("app.atom", "w") as zip_file:
     zip_file.writestr("cpg.proto", bytes(atom_struct))
 ```
-
-## Environment variables
-
-- CHEN_IGNORE_TEST_DIRS: Set to true to ignore `test` directories. Only supported for Python for now.
-- CHEN_PYTHON_IGNORE_DIRS: Comma-separated list of directories to ignore for Python.
 
 ## License
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -46,13 +46,23 @@ Extract reachable data-flow slices based on automated framework tags
 
 ## Environment variables
 
-| Variable                      | Description                                                                                   |
-| ----------------------------- | --------------------------------------------------------------------------------------------- |
-| **CHEN_IGNORE_TEST_DIRS**     | Set to true to ignore `test` directories. Only supported for Python for now.                  |
-| **CHEN_PYTHON_IGNORE_DIRS**   | Comma-separated list of directories to ignore for Python.                                     |
-| **CHEN_DELOMBOK_MODE**        | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`). |
-| **CHEN_INCLUDE_PATH**         | Include directories for the C frontend. Separate paths with `:` or `;`.                       |
-| **ATOM_TOOLS_OPENAPI_FORMAT** | OpenAPI format for atom-tools. Default: `openapi3.1.0`; alternative: `openapi3.0.1`.          |
-| **ATOM_TOOLS_WORK_DIR**       | Working directory for atom-tools. Defaults to atom input path.                                |
-| **ATOM_SCALASEM_WORK_DIR**    | Working directory for scalasem. Defaults to atom input path.                                  |
-| **ATOM_SCALASEM_SLICES_FILE** | Slices file name. Defaults to `semantics.slices.json`.                                        |
+| Variable                       | Description                                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| **CHEN_IGNORE_TEST_DIRS**      | Set to true to ignore `test` directories. Only supported for Python for now.                        |
+| **CHEN_PYTHON_IGNORE_DIRS**    | Comma-separated list of directories to ignore for Python.                                           |
+| **CHEN_DELOMBOK_MODE**         | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`).       |
+| **CHEN_INCLUDE_PATH**          | Include directories for the C frontend. Separate paths with `:` or `;`.                             |
+| **ATOM_TOOLS_OPENAPI_FORMAT**  | OpenAPI format for atom-tools. Default: `openapi3.1.0`; alternative: `openapi3.0.1`.                |
+| **ATOM_TOOLS_WORK_DIR**        | Working directory for atom-tools. Defaults to atom input path.                                      |
+| **ATOM_SCALASEM_WORK_DIR**     | Working directory for scalasem. Defaults to atom input path.                                        |
+| **ATOM_SCALASEM_SLICES_FILE**  | Slices file name. Defaults to `semantics.slices.json`.                                              |
+| **ATOM_JVM_ARGS**              | Overrides the JVM arguments, including heap memory values, constructed by the atom Node.js wrapper. |
+| **ATOM_JAVA_HOME**             | Java 21 or above to be used by atom.                                                                |
+| **PHP_CMD**                    | Overrides the PHP command used by the PHP frontend.                                                 |
+| **PHP_PARSER_BIN**             | Overrides the php-parse command used by the PHP frontend.                                           |
+| **SCALA_CMD**                  | Overrides the scala command.                                                                        |
+| **SCALAC_CMD**                 | Overrides the scalac command used by the scala frontend.                                            |
+| **ASTGEN_IGNORE_DIRS**         | Comma-separated list of directories to ignore by the JavaScript astgen pre-processor command.       |
+| **ASTGEN_IGNORE_FILE_PATTERN** | File pattern to ignore by the JavaScript astgen pre-processor command.                              |
+| **JAVA_CMD**                   | Overrides the java command.                                                                         |
+| **RUBY_CMD**                   | Overrides the Ruby command.                                                                         |

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -43,3 +43,16 @@ Extract reachable data-flow slices based on automated framework tags
   --include-crypto         includes crypto library flows - defaults to false.
   --help                   display this help message
 ```
+
+## Environment variables
+
+| Variable                      | Description                                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| **CHEN_IGNORE_TEST_DIRS**     | Set to true to ignore `test` directories. Only supported for Python for now.                  |
+| **CHEN_PYTHON_IGNORE_DIRS**   | Comma-separated list of directories to ignore for Python.                                     |
+| **CHEN_DELOMBOK_MODE**        | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`). |
+| **CHEN_INCLUDE_PATH**         | Include directories for the C frontend. Separate paths with `:` or `;`.                       |
+| **ATOM_TOOLS_OPENAPI_FORMAT** | OpenAPI format for atom-tools. Default: `openapi3.1.0`; alternative: `openapi3.0.1`.          |
+| **ATOM_TOOLS_WORK_DIR**       | Working directory for atom-tools. Defaults to atom input path.                                |
+| **ATOM_SCALASEM_WORK_DIR**    | Working directory for scalasem. Defaults to atom input path.                                  |
+| **ATOM_SCALASEM_SLICES_FILE** | Slices file name. Defaults to `semantics.slices.json`.                                        |

--- a/wrapper/nodejs/index.js
+++ b/wrapper/nodejs/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { freemem, platform as _platform } from "node:os";
+import { freemem, totalmem, platform as _platform } from "node:os";
 import { dirname, join, delimiter } from "node:path";
 import { readFileSync } from "node:fs";
 
@@ -20,11 +20,18 @@ export const LOG4J_CONFIG = join(dirName, "plugins", "log4j2.xml");
 export const ATOM_HOME = join(dirName, "plugins");
 export const APP_LIB_DIR = join(ATOM_HOME, "lib");
 export const PHP_PARSER_BIN = join(ATOM_HOME, "bin", "php-parse");
-const freeMemoryGB = Math.max(Math.floor(freemem() / 1024 / 1024 / 1024), 4);
+
+// We need more memory for atom to work well
+const maxMemoryGB = Math.max(
+  Math.floor((totalmem() * 0.8) / 1024 ** 3),
+  Math.floor(freemem() / 1024 ** 3)
+);
+
 export const JVM_ARGS = "-XX:+UseG1GC -XX:+UseStringDeduplication";
-export const JAVA_OPTS = `${
-  process.env.JAVA_OPTS || ""
-} -Xmx${freeMemoryGB}G ${JVM_ARGS}`;
+export const JAVA_OPTS =
+  process.env?.ATOM_JVM_ARGS ||
+  `${process.env.JAVA_OPTS || ""} -Xms2G -Xmx${maxMemoryGB}G ${JVM_ARGS}`;
+
 export const APP_MAIN_CLASS = "io.appthreat.atom.Atom";
 export const ATOM_VERSION = _version;
 export const APP_CLASSPATH = join(

--- a/wrapper/nodejs/index.js
+++ b/wrapper/nodejs/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { freemem, totalmem, platform as _platform } from "node:os";
+import { totalmem, platform as _platform } from "node:os";
 import { dirname, join, delimiter } from "node:path";
 import { readFileSync } from "node:fs";
 
@@ -22,10 +22,7 @@ export const APP_LIB_DIR = join(ATOM_HOME, "lib");
 export const PHP_PARSER_BIN = join(ATOM_HOME, "bin", "php-parse");
 
 // We need more memory for atom to work well
-const maxMemoryGB = Math.max(
-  Math.floor((totalmem() * 0.8) / 1024 ** 3),
-  Math.floor(freemem() / 1024 ** 3)
-);
+const maxMemoryGB = Math.floor((totalmem() * 0.8) / 1024 ** 3);
 
 export const JVM_ARGS = "-XX:+UseG1GC -XX:+UseStringDeduplication";
 export const JAVA_OPTS =


### PR DESCRIPTION
Certain kinds of flows were only collected when the other queries didn't yield results.

```
if flowSlices.isEmpty
```

Replaced this with `defaultTagsMode` check, which sounds sensible.