### PR TITLE
Switch to mandrel for native builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'graalvm-community'
+          distribution: 'mandrel'
           java-version: '23'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
@@ -36,8 +36,8 @@ jobs:
         with:
           arch: amd64
       - run: |
-          Invoke-WebRequest -Uri https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-win64.zip -UseBasicParsing -OutFile upx-5.0.0-win64.zip
-          Expand-Archive -Path upx-5.0.0-win64.zip -DestinationPath . -Force
+          Invoke-WebRequest -Uri https://github.com/upx/upx/releases/download/v5.0.1/upx-5.0.1-win64.zip -UseBasicParsing -OutFile upx-5.0.1-win64.zip
+          Expand-Archive -Path upx-5.0.1-win64.zip -DestinationPath . -Force
           sbt stage createDistribution
           sbt "GraalVMNativeImage / packageBin"
           .\target\graalvm-native-image\atom.exe --help
@@ -67,7 +67,7 @@ jobs:
       - name: Set up JDK
         uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'graalvm-community'
+          distribution: 'mandrel'
           java-version: '23'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
@@ -78,10 +78,10 @@ jobs:
           apps: scala3 scalac
       - uses: oras-project/setup-oras@v1
       - run: |
-          wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-amd64_linux.tar.xz
-          tar -xvf upx-5.0.0-amd64_linux.tar.xz
-          chmod +x upx-5.0.0-amd64_linux/upx
-          sudo cp upx-5.0.0-amd64_linux/upx /usr/local/bin/
+          wget https://github.com/upx/upx/releases/download/v5.0.1/upx-5.0.1-amd64_linux.tar.xz
+          tar -xvf upx-5.0.1-amd64_linux.tar.xz
+          chmod +x upx-5.0.1-amd64_linux/upx
+          sudo cp upx-5.0.1-amd64_linux/upx /usr/local/bin/
           sbt stage createDistribution
           sha512sum target/atom.zip > target/atom.zip.sha512
           bash ci/native-image.sh
@@ -142,7 +142,7 @@ jobs:
       - name: Set up JDK
         uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'graalvm-community'
+          distribution: 'mandrel'
           java-version: '23'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
@@ -153,10 +153,10 @@ jobs:
           apps: scala3 scalac
       - uses: oras-project/setup-oras@v1
       - run: |
-          wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-arm64_linux.tar.xz
-          tar -xvf upx-5.0.0-arm64_linux.tar.xz
-          chmod +x upx-5.0.0-arm64_linux/upx
-          sudo cp upx-5.0.0-arm64_linux/upx /usr/local/bin/
+          wget https://github.com/upx/upx/releases/download/v5.0.1/upx-5.0.1-arm64_linux.tar.xz
+          tar -xvf upx-5.0.1-arm64_linux.tar.xz
+          chmod +x upx-5.0.1-arm64_linux/upx
+          sudo cp upx-5.0.1-arm64_linux/upx /usr/local/bin/
           sbt stage createDistribution
           bash ci/native-image.sh
           cp target/graalvm-native-image/atom target/graalvm-native-image/atom-arm64
@@ -199,7 +199,7 @@ jobs:
       - name: Set up JDK
         uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'graalvm-community'
+          distribution: 'mandrel'
           java-version: '23'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/build.sbt
+++ b/build.sbt
@@ -123,10 +123,12 @@ credentials +=
       "appthreat",
       sys.env.getOrElse("GITHUB_TOKEN", "N/A")
     )
+
+// Mandrel-based builds are released under version 2 of the GNU General Public License with the “Classpath” Exception - https://github.com/graalvm/mandrel/blob/default/LICENSE
 graalVMNativeImageOptions := Seq(
   "-H:+UnlockExperimentalVMOptions",
   "-R:MaximumHeapSizePercent=90", // Reduce for more predictable and deterministic slicing
-  "-H:+UseEpsilonGC",
+  "--gc=epsilon",
   "--initialize-at-build-time=io.appthreat.*",
   "--no-fallback"
 )

--- a/ci/native-image.sh
+++ b/ci/native-image.sh
@@ -10,7 +10,8 @@ if [ -f "target/graalvm-native-image/atom" ]; then
     chmod +x target/graalvm-native-image/atom
     target/graalvm-native-image/atom --help
     echo "atom native-image was built successfully."
-    echo "Using Oracle GraalVM 23? Adhere to the terms of the license - https://www.oracle.com/downloads/licenses/graal-free-license.html"
+    echo "Mandrel-based builds are released under version 2 of the GNU General Public License with the “Classpath” Exception - https://github.com/graalvm/mandrel/blob/default/LICENSE"
+    echo "Using Oracle GraalVM to build this image? Adhere to the terms of the license - https://www.oracle.com/downloads/licenses/graal-free-license.html"
 else
     echo "atom native-image was not built correctly. Check if you have Oracle GraalVM 23 installed."
 fi

--- a/src/main/scala/io/appthreat/atom/slicing/ReachableSlicing.scala
+++ b/src/main/scala/io/appthreat/atom/slicing/ReachableSlicing.scala
@@ -160,7 +160,16 @@ object ReachableSlicing:
         )
       end if
     end if
-    ReachableSlice(flowSlices.flatten.map(toSlice).toList)
+    val slicesList = flowSlices.flatten.map(toSlice).toList
+    if slicesList.isEmpty then
+      println(
+        s"No Reachable Flows identified for the given source tags: ${config.sourceTag} and sink tags: ${config.sinkTag}"
+      )
+      def atomTags =
+          atom.tag.name.filterNot(t => t.startsWith("pkg:") || t.toUpperCase().equals(t)).toSet
+      if atomTags.nonEmpty then
+        println(raw"List of semantic tags found in the atom file:\n${atomTags.mkString("\n")}")
+    ReachableSlice(slicesList)
   end calculateReachableSlice
 
   private def tagAsString(tag: Iterator[Tag]): String =


### PR DESCRIPTION
With Mandrel, we avoid the confusions created by the Graal Free License. Things are still blurry, since nothing free from Oracle is really free.
Helpful message for empty reachable slices.