### PR TITLE
atom is no longer afraid of minified and transpiled js code

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -1,8 +1,9 @@
 name: repotests
 on:
+  pull_request:
   push:
     branches:
-      - feature/*
+      - main
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.4.0"
+ThisBuild / version      := "2.4.1"
 ThisBuild / scalaVersion := "3.7.3"
 
-val chenVersion = "2.5.1"
+val chenVersion = "2.5.3"
 
 lazy val atom = Projects.atom
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/atom-parsetools",
@@ -1788,16 +1788,16 @@
     },
     "packages/atom-common": {
       "name": "@appthreat/atom-common",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "devDependencies": {}
     },
     "packages/atom-parsetools": {
       "name": "@appthreat/atom-parsetools",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
-        "@appthreat/atom-common": "^1.0.9",
+        "@appthreat/atom-common": "^1.0.10",
         "@babel/parser": "^7.28.4",
         "typescript": "^5.9.2",
         "yargs": "^17.7.2"

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",

--- a/wrapper/nodejs/packages/atom-common/package.json
+++ b/wrapper/nodejs/packages/atom-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom-common",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Common library for the @appthreat/atom project.",
   "main": "index.js",
   "type": "module",

--- a/wrapper/nodejs/packages/atom-common/utils.mjs
+++ b/wrapper/nodejs/packages/atom-common/utils.mjs
@@ -5,11 +5,8 @@ import { spawnSync } from "node:child_process";
 const IGNORE_DIRS = process.env.ASTGEN_IGNORE_DIRS
   ? process.env.ASTGEN_IGNORE_DIRS.split(",")
   : [
-      "node_modules",
       "venv",
       "docs",
-      "test",
-      "tests",
       "e2e",
       "e2e-beta",
       "examples",
@@ -19,20 +16,15 @@ const IGNORE_DIRS = process.env.ASTGEN_IGNORE_DIRS
       "codemods",
       "flow-typed",
       "i18n",
-      "vendor",
-      "www",
-      "dist",
-      "build",
-      "__tests__"
     ];
 
 const IGNORE_FILE_PATTERN = new RegExp(
   process.env.ASTGEN_IGNORE_FILE_PATTERN ||
-    "(test|spec|min|three|\\.d)\\.(js|ts|jsx|tsx)$",
+    "(three|\\.d)\\.(js|ts|jsx|tsx)$",
   "i"
 );
 
-export const getAllFiles = (dir, extn, files, result, regex) => {
+export const getAllFiles = (dir, extn, files, result, regex, ignore_node_modules=true) => {
   files = files || readdirSync(dir);
   result = result || [];
   regex = regex || new RegExp(`\\${extn}$`);
@@ -40,9 +32,8 @@ export const getAllFiles = (dir, extn, files, result, regex) => {
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     if (
-      file.startsWith(".") ||
-      file.startsWith("__") ||
-      IGNORE_FILE_PATTERN.test(file)
+          file.startsWith(".") ||
+          IGNORE_FILE_PATTERN.test(file)
     ) {
       continue;
     }
@@ -52,8 +43,8 @@ export const getAllFiles = (dir, extn, files, result, regex) => {
       const dirName = basename(fileWithDir);
       if (
         dirName.startsWith(".") ||
-        dirName.startsWith("__") ||
-        IGNORE_DIRS.includes(dirName.toLowerCase())
+        IGNORE_DIRS.includes(dirName.toLowerCase()) ||
+        (ignore_node_modules && dirName.toLowerCase() === "node_modules")
       ) {
         continue;
       }
@@ -63,7 +54,8 @@ export const getAllFiles = (dir, extn, files, result, regex) => {
           extn,
           readdirSync(fileWithDir),
           result,
-          regex
+          regex,
+          ignore_node_modules
         );
       } catch (error) {
         // ignore

--- a/wrapper/nodejs/packages/atom-parsetools/.eslintrc.cjs
+++ b/wrapper/nodejs/packages/atom-parsetools/.eslintrc.cjs
@@ -1,15 +1,13 @@
 module.exports = {
-    "env": {
-        "node": true,
-        "es2021": true
-    },
-    "extends": "eslint:recommended",
-    "overrides": [
-    ],
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "rules": {
-    }
-}
+  env: {
+    node: true,
+    es2021: true
+  },
+  extends: "eslint:recommended",
+  overrides: [],
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module"
+  },
+  rules: {}
+};

--- a/wrapper/nodejs/packages/atom-parsetools/package.json
+++ b/wrapper/nodejs/packages/atom-parsetools/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@appthreat/atom-parsetools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Parsing tools that complement the @appthreat/atom project.",
   "main": "./index.js",
   "type": "module",
   "scripts": {
-    "pretty": "prettier --write *.mjs *.js --trailing-comma=none",
+    "pretty": "prettier --write *.cjs *.js --trailing-comma=none",
     "lint": "eslint *.mjs *.js"
   },
   "dependencies": {
-    "@appthreat/atom-common": "^1.0.9",
+    "@appthreat/atom-common": "^1.0.10",
     "@babel/parser": "^7.28.4",
     "typescript": "^5.9.2",
     "yargs": "^17.7.2"


### PR DESCRIPTION
Powered by chen 2.5.3, atom can now parse and slice large js projects that include transpiled and minified dependencies.

<img width="2003" height="1213" alt="chennai-aaa" src="https://github.com/user-attachments/assets/eb284060-c6ed-423f-84fc-031747dc252f" />
<img width="2003" height="1213" alt="chennai-encode-log" src="https://github.com/user-attachments/assets/3ec23c3a-f3ba-4af7-be6c-cf6d0cafd197" />
