### PR TITLE
update chen version to get c/c++ improvements and security fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.4.1"
+ThisBuild / version      := "2.4.2"
 ThisBuild / scalaVersion := "3.7.3"
 
-val chenVersion = "2.5.3"
+val chenVersion = "2.5.4"
 
 lazy val atom = Projects.atom
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "workspaces": [
         "packages/atom-parsetools",
@@ -1788,16 +1788,16 @@
     },
     "packages/atom-common": {
       "name": "@appthreat/atom-common",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "devDependencies": {}
     },
     "packages/atom-parsetools": {
       "name": "@appthreat/atom-parsetools",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
-        "@appthreat/atom-common": "^1.0.10",
+        "@appthreat/atom-common": "^1.0.11",
         "@babel/parser": "^7.28.4",
         "typescript": "^5.9.2",
         "yargs": "^17.7.2"

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",

--- a/wrapper/nodejs/packages/atom-common/package.json
+++ b/wrapper/nodejs/packages/atom-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom-common",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Common library for the @appthreat/atom project.",
   "main": "index.js",
   "type": "module",

--- a/wrapper/nodejs/packages/atom-parsetools/package.json
+++ b/wrapper/nodejs/packages/atom-parsetools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom-parsetools",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Parsing tools that complement the @appthreat/atom project.",
   "main": "./index.js",
   "type": "module",
@@ -9,7 +9,7 @@
     "lint": "eslint *.mjs *.js"
   },
   "dependencies": {
-    "@appthreat/atom-common": "^1.0.10",
+    "@appthreat/atom-common": "^1.0.11",
     "@babel/parser": "^7.28.4",
     "typescript": "^5.9.2",
     "yargs": "^17.7.2"


### PR DESCRIPTION
chen 2.5.4 includes the updated overflowdb version and removes the need for the commons-lang package to fix [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v).