### PR TITLE
feat(frontends): extend ignored directories support via environment v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,19 @@ atom -o app.atom -l java --export-atom --export-dir <export dir> --with-data-dep
 
 | Variable                                | Description                                                                                                                                                |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CHEN_IGNORE_TEST_DIRS**               | Set to true to ignore `test` directories. Only supported for Python for now.                                                                               |
-| **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python.                                                                                                  |
+| **CHEN_IGNORE_DIRS**                    | Comma-separated list of directories to ignore for every language frontend.                                                                                 |
+| **CHEN_IGNORE_TEST_DIRS**               | Set to true to ignore common test directories (`test`, `tests`, `mocks`) for every language frontend.                                                      |
+| **CHEN_C_IGNORE_DIRS**                  | Comma-separated list of additional directories to ignore for the C/C++ and header frontends.                                                               |
+| **CHEN_CPP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the C++ frontend.                                                                             |
+| **CHEN_JAVA_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Java source frontend.                                                                     |
+| **CHEN_JIMPLE_IGNORE_DIRS**             | Comma-separated list of directories to ignore for the Jimple/JAR/Android/APK/DEX frontend.                                                                 |
+| **CHEN_SCALA_IGNORE_DIRS**              | Comma-separated list of directories to ignore for the Scala frontend.                                                                                      |
+| **CHEN_JAVASCRIPT_IGNORE_DIRS**         | Comma-separated list of directories to ignore for the JavaScript, TypeScript, and Flow frontend.                                                           |
+| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript and TypeScript ignored directories.                                                                                                   |
+| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript ignored directories.                                                                                                                  |
+| **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python. If unset, Atom uses Python's default ignored directories.                                        |
+| **CHEN_PHP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the PHP frontend.                                                                             |
+| **CHEN_RUBY_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Ruby frontend.                                                                            |
 | **CHEN_DELOMBOK_MODE**                  | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`).                                                              |
 | **CHEN_INCLUDE_PATH**                   | Include directories for the C frontend. Separate paths with `:` or `;`.                                                                                    |
 | **CHEN_ASTGEN_OUT**                     | Existing astgen output directory. Improves performance for JavaScript, TypeScript, and Flow during repeated invocations by reusing existing AST json data. |

--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ atom -o app.atom -l java --export-atom --export-dir <export dir> --with-data-dep
 | **CHEN_JIMPLE_IGNORE_DIRS**             | Comma-separated list of directories to ignore for the Jimple/JAR/Android/APK/DEX frontend.                                                                 |
 | **CHEN_SCALA_IGNORE_DIRS**              | Comma-separated list of directories to ignore for the Scala frontend.                                                                                      |
 | **CHEN_JAVASCRIPT_IGNORE_DIRS**         | Comma-separated list of directories to ignore for the JavaScript, TypeScript, and Flow frontend.                                                           |
-| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript and TypeScript ignored directories.                                                                                                   |
-| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript ignored directories.                                                                                                                  |
+| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript, TypeScript, and Flow ignored directories.                                                                                            |
+| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript and Flow ignored directories.                                                                                                         |
 | **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python. If unset, Atom uses Python's default ignored directories.                                        |
 | **CHEN_PHP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the PHP frontend.                                                                             |
 | **CHEN_RUBY_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Ruby frontend.                                                                            |

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "atom"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.5.3"
+ThisBuild / version      := "2.5.4"
 ThisBuild / scalaVersion := "3.8.3"
 
 val chenVersion = "2.5.20"

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/atom",
   "issueTracker": "https://github.com/AppThreat/atom/issues",
   "name": "atom",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Atom is a novel intermediate representation for next-generation code analysis.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -50,8 +50,19 @@ Extract reachable data-flow slices based on automated framework tags
 
 | Variable                                | Description                                                                                                                                                |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CHEN_IGNORE_TEST_DIRS**               | Set to true to ignore `test` directories. Only supported for Python for now.                                                                               |
-| **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python.                                                                                                  |
+| **CHEN_IGNORE_DIRS**                    | Comma-separated list of directories to ignore for every language frontend.                                                                                 |
+| **CHEN_IGNORE_TEST_DIRS**               | Set to true to ignore common test directories (`test`, `tests`, `mocks`) for every language frontend.                                                     |
+| **CHEN_C_IGNORE_DIRS**                  | Comma-separated list of additional directories to ignore for the C/C++ and header frontends.                                                              |
+| **CHEN_CPP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the C++ frontend.                                                                             |
+| **CHEN_JAVA_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Java source frontend.                                                                     |
+| **CHEN_JIMPLE_IGNORE_DIRS**             | Comma-separated list of directories to ignore for the Jimple/JAR/Android/APK/DEX frontend.                                                                |
+| **CHEN_SCALA_IGNORE_DIRS**              | Comma-separated list of directories to ignore for the Scala frontend.                                                                                      |
+| **CHEN_JAVASCRIPT_IGNORE_DIRS**         | Comma-separated list of directories to ignore for the JavaScript, TypeScript, and Flow frontend.                                                          |
+| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript and TypeScript ignored directories.                                                                                                   |
+| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript ignored directories.                                                                                                                  |
+| **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python. If unset, Atom uses Python's default ignored directories.                                        |
+| **CHEN_PHP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the PHP frontend.                                                                             |
+| **CHEN_RUBY_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Ruby frontend.                                                                            |
 | **CHEN_DELOMBOK_MODE**                  | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`).                                                              |
 | **CHEN_INCLUDE_PATH**                   | Include directories for the C frontend. Separate paths with `:` or `;`.                                                                                    |
 | **CHEN_ASTGEN_OUT**                     | Existing astgen output directory. Improves performance for JavaScript, TypeScript, and Flow during repeated invocations by reusing existing AST json data. |

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -58,8 +58,8 @@ Extract reachable data-flow slices based on automated framework tags
 | **CHEN_JIMPLE_IGNORE_DIRS**             | Comma-separated list of directories to ignore for the Jimple/JAR/Android/APK/DEX frontend.                                                                |
 | **CHEN_SCALA_IGNORE_DIRS**              | Comma-separated list of directories to ignore for the Scala frontend.                                                                                      |
 | **CHEN_JAVASCRIPT_IGNORE_DIRS**         | Comma-separated list of directories to ignore for the JavaScript, TypeScript, and Flow frontend.                                                          |
-| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript and TypeScript ignored directories.                                                                                                   |
-| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript ignored directories.                                                                                                                  |
+| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript, TypeScript, and Flow ignored directories.                                                                                            |
+| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript and Flow ignored directories.                                                                                                         |
 | **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python. If unset, Atom uses Python's default ignored directories.                                        |
 | **CHEN_PHP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the PHP frontend.                                                                             |
 | **CHEN_RUBY_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Ruby frontend.                                                                            |

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -96,24 +96,29 @@ object Atom:
     "virtualenvs",
     "venv",
     "benchmarks",
-    "tutorials",
-    "noxfile"
+    "tutorials"
   )
-  private val testIgnoreDirs = Seq("test", "tests", "mocks")
+  private val defaultPythonIgnorePathFragments = Seq("noxfile")
+  private val testIgnoreDirs                   = Seq("test", "tests", "mocks")
   private val ignoreTestDirs: Boolean =
       Option(System.getenv("CHEN_IGNORE_TEST_DIRS"))
           .exists(_.trim.equalsIgnoreCase("true"))
-  private val pythonIgnoreDirsEnv = "CHEN_PYTHON_IGNORE_DIRS"
+  private val pythonIgnoreDirsEnv                   = "CHEN_PYTHON_IGNORE_DIRS"
+  private val pythonSpecificIgnoreDirs: Seq[String] = envSpecificIgnoreDirs(pythonIgnoreDirsEnv)
   private val basePythonIgnoreDirs: Seq[String] =
-    val pythonSpecificIgnoreDirs = envSpecificIgnoreDirs(pythonIgnoreDirsEnv)
     val pythonBaseIgnoreDirs = pythonSpecificIgnoreDirs match
       case Seq() => defaultPythonIgnoreDirs
       case dirs  => dirs
     (pythonBaseIgnoreDirs ++ commonIgnoreDirs).distinct
   private val pyIgnoreDirs: Seq[String] = appendTestIgnoreDirs(basePythonIgnoreDirs)
+  private val pythonIgnorePathFragments: Seq[String] = pythonSpecificIgnoreDirs match
+    case Seq() => defaultPythonIgnorePathFragments
+    case _     => Seq.empty
   // This regex will be eventually passed to chen
-  private val pythonIgnoredFilesRegex: String = ignoredPathFragmentsRegex(pyIgnoreDirs)
-      .getOrElse("$^")
+  private val pythonIgnoredFilesRegex: String = combineIgnoredFilesRegex(
+    ignoredDirectoriesRegex(pyIgnoreDirs),
+    ignoredPathFragmentsRegex(pythonIgnorePathFragments)
+  )
 
   private def parseIgnoreDirs(value: String): Seq[String] =
       value.split(',').map(_.trim).filter(_.nonEmpty).toSeq

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -789,6 +789,10 @@ object Atom:
         extractArgBoolean(config, "enable-ast-cache", default = false) || onlyAstCache
     val defaultCacheDir = (config.inputPath / "ast_out").pathAsString
     val cacheDir        = extractArgString(config, "ast-cache-dir", default = defaultCacheDir)
+    val cIgnoreDirEnvVars =
+        if config.language.equalsIgnoreCase("CPP") || config.language.equalsIgnoreCase("C++") then
+          Seq("CHEN_C_IGNORE_DIRS", "CHEN_CPP_IGNORE_DIRS")
+        else Seq("CHEN_C_IGNORE_DIRS")
     val baseConfig = CConfig(
       includeComments = includeComments,
       logProblems = false,
@@ -798,9 +802,7 @@ object Atom:
         .withInputPath(config.inputPath.pathAsString)
         .withOutputPath(outputAtomFile)
         .withFunctionBodies(functionBodies)
-        .withIgnoredFilesRegex(
-          ignoredFilesRegex(COMMON_IGNORE_REGEX, "CHEN_C_IGNORE_DIRS", "CHEN_CPP_IGNORE_DIRS")
-        )
+        .withIgnoredFilesRegex(ignoredFilesRegex(COMMON_IGNORE_REGEX, cIgnoreDirEnvVars*))
         .withParseInactiveCode(parseInactive)
         .withImageLocations(imageLocations)
         .withIncludeTrivialExpressions(includeTrivialExpressions)
@@ -887,11 +889,15 @@ object Atom:
     val astGenConfig = sys.env.get("CHEN_ASTGEN_OUT") match
       case Some(dir) => initialConfig.withAstGenOutDir(dir)
       case None      => initialConfig
-    val finalConfig = ignoredFilesRegexFromEnv(
-      "CHEN_JAVASCRIPT_IGNORE_DIRS",
-      "CHEN_JS_IGNORE_DIRS",
-      "CHEN_TYPESCRIPT_IGNORE_DIRS"
-    ) match
+    val jsIgnoreDirEnvVars =
+        if config.language.equalsIgnoreCase("TS") || config.language.equalsIgnoreCase(
+            "TYPESCRIPT"
+          ) ||
+          config.language.equalsIgnoreCase("FLOW")
+        then
+          Seq("CHEN_JAVASCRIPT_IGNORE_DIRS", "CHEN_JS_IGNORE_DIRS", "CHEN_TYPESCRIPT_IGNORE_DIRS")
+        else Seq("CHEN_JAVASCRIPT_IGNORE_DIRS", "CHEN_JS_IGNORE_DIRS")
+    val finalConfig = ignoredFilesRegexFromEnv(jsIgnoreDirEnvVars*) match
       case Some(regex) => astGenConfig.withIgnoredFilesRegex(regex)
       case None        => astGenConfig
     new JsSrc2Cpg()

--- a/src/main/scala/io/appthreat/atom/Atom.scala
+++ b/src/main/scala/io/appthreat/atom/Atom.scala
@@ -40,6 +40,7 @@ import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import scopt.OptionParser
 
 import java.util.Locale
+import java.util.regex.Pattern
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
@@ -83,6 +84,11 @@ object Atom:
         "pkg.*"
       )
   private val COMMON_IGNORE_REGEX = ".*(docs|example|samples|mocks|Documentation|demos).*"
+  private val JAVA_IGNORE_REGEX   = ".*(target|build)/(generated|intermediates|outputs|tmp).*"
+  private val PHP_IGNORE_REGEX    = ".*(samples|examples|docs).*"
+  private val RUBY_IGNORE_REGEX   = ".*(docs|vendor|spec).*"
+
+  private val COMMON_IGNORE_DIRS_ENV = "CHEN_IGNORE_DIRS"
   // Identify directories to ignore for python
   private val defaultPythonIgnoreDirs = Seq(
     "samples",
@@ -94,17 +100,67 @@ object Atom:
     "noxfile"
   )
   private val testIgnoreDirs = Seq("test", "tests", "mocks")
-  private val basePythonIgnoreDirs: Seq[String] = Option(System.getenv("CHEN_PYTHON_IGNORE_DIRS"))
-      .map(_.split(',').map(_.trim).filter(_.nonEmpty).toSeq)
-      .getOrElse(defaultPythonIgnoreDirs)
-  private val includeTestDirs: Boolean =
+  private val ignoreTestDirs: Boolean =
       Option(System.getenv("CHEN_IGNORE_TEST_DIRS"))
           .exists(_.trim.equalsIgnoreCase("true"))
-  private val pyIgnoreDirs: Seq[String] =
-      if includeTestDirs then basePythonIgnoreDirs ++ testIgnoreDirs
-      else basePythonIgnoreDirs
+  private val pythonIgnoreDirsEnv = "CHEN_PYTHON_IGNORE_DIRS"
+  private val basePythonIgnoreDirs: Seq[String] =
+    val pythonSpecificIgnoreDirs = envSpecificIgnoreDirs(pythonIgnoreDirsEnv)
+    val pythonBaseIgnoreDirs = pythonSpecificIgnoreDirs match
+      case Seq() => defaultPythonIgnoreDirs
+      case dirs  => dirs
+    (pythonBaseIgnoreDirs ++ commonIgnoreDirs).distinct
+  private val pyIgnoreDirs: Seq[String] = appendTestIgnoreDirs(basePythonIgnoreDirs)
   // This regex will be eventually passed to chen
-  private val pythonIgnoredFilesRegex: String = ".*(" + pyIgnoreDirs.mkString("|") + ").*"
+  private val pythonIgnoredFilesRegex: String = ignoredPathFragmentsRegex(pyIgnoreDirs)
+      .getOrElse("$^")
+
+  private def parseIgnoreDirs(value: String): Seq[String] =
+      value.split(',').map(_.trim).filter(_.nonEmpty).toSeq
+
+  private def commonIgnoreDirs: Seq[String] =
+      envSpecificIgnoreDirs(COMMON_IGNORE_DIRS_ENV)
+
+  private def envIgnoreDirs(envVars: String*): Seq[String] =
+      (commonIgnoreDirs ++ envSpecificIgnoreDirs(envVars*)).distinct
+
+  private def envSpecificIgnoreDirs(envVars: String*): Seq[String] =
+      envVars.flatMap(envVar => Option(System.getenv(envVar)).toSeq.flatMap(parseIgnoreDirs))
+          .distinct
+
+  private def appendTestIgnoreDirs(ignoreDirs: Seq[String]): Seq[String] =
+      if ignoreTestDirs then (ignoreDirs ++ testIgnoreDirs).distinct
+      else ignoreDirs.distinct
+
+  private def ignoredPathFragmentsRegex(ignoreDirs: Seq[String]): Option[String] =
+    val escapedPathFragments = ignoreDirs.filter(_.nonEmpty).map(Pattern.quote)
+    Option.when(escapedPathFragments.nonEmpty)(s".*(?:${escapedPathFragments.mkString("|")}).*")
+
+  private def ignoredDirectoriesRegex(ignoreDirs: Seq[String]): Option[String] =
+    val directoryPatterns = ignoreDirs.map(toDirectoryRegex).filter(_.nonEmpty)
+    Option.when(directoryPatterns.nonEmpty) {
+        s"(?:^|.*[/\\\\])(?:${directoryPatterns.mkString("|")})(?:[/\\\\].*|$$)"
+    }
+
+  private def toDirectoryRegex(ignoreDir: String): String =
+      ignoreDir
+          .replace('\\', '/')
+          .stripPrefix("./")
+          .stripPrefix("/")
+          .stripSuffix("/")
+          .split("/+")
+          .filter(_.nonEmpty)
+          .map(Pattern.quote)
+          .mkString("[/\\\\]")
+
+  private def ignoredFilesRegexFromEnv(envVars: String*): Option[String] =
+      ignoredDirectoriesRegex(appendTestIgnoreDirs(envIgnoreDirs(envVars*)))
+
+  private def ignoredFilesRegex(defaultRegex: String, envVars: String*): String =
+      combineIgnoredFilesRegex(Some(defaultRegex), ignoredFilesRegexFromEnv(envVars*))
+
+  private def combineIgnoredFilesRegex(regexes: Option[String]*): String =
+      regexes.flatten.filter(_.nonEmpty).map(regex => s"(?:$regex)").mkString("|")
 
   val DEFAULT_EXPORT_DIR: String = "atom-exports"
   // Possible values: graphml, dot
@@ -698,7 +754,7 @@ object Atom:
         .withInputPath(config.inputPath.pathAsString)
         .withOutputPath(outputAtomFile)
         .withFunctionBodies(false)
-        .withIgnoredFilesRegex(".*(docs|example|samples|mocks|Documentation|demos).*")
+        .withIgnoredFilesRegex(ignoredFilesRegex(COMMON_IGNORE_REGEX, "CHEN_C_IGNORE_DIRS"))
         .withParseInactiveCode(false)
         .withImageLocations(false)
         .withIncludeTrivialExpressions(false)
@@ -737,7 +793,9 @@ object Atom:
         .withInputPath(config.inputPath.pathAsString)
         .withOutputPath(outputAtomFile)
         .withFunctionBodies(functionBodies)
-        .withIgnoredFilesRegex(".*(docs|example|samples|mocks|Documentation|demos).*")
+        .withIgnoredFilesRegex(
+          ignoredFilesRegex(COMMON_IGNORE_REGEX, "CHEN_C_IGNORE_DIRS", "CHEN_CPP_IGNORE_DIRS")
+        )
         .withParseInactiveCode(parseInactive)
         .withImageLocations(imageLocations)
         .withIncludeTrivialExpressions(includeTrivialExpressions)
@@ -753,14 +811,16 @@ object Atom:
   end createC2Cpg
 
   private def createJimple2Cpg(config: AtomConfig, outputAtomFile: String): Try[Cpg] =
-      new Jimple2Cpg().createCpgWithOverlays(
-        JimpleConfig(android = androidJarPath, fullResolver = true)
-            .withRecurse(true)
-            .withDepth(10)
-            .withInputPath(config.inputPath.pathAsString)
-            .withOutputPath(outputAtomFile)
-            .withFullResolver(true)
-      )
+    val baseConfig = JimpleConfig(android = androidJarPath, fullResolver = true)
+        .withRecurse(true)
+        .withDepth(10)
+        .withInputPath(config.inputPath.pathAsString)
+        .withOutputPath(outputAtomFile)
+        .withFullResolver(true)
+    val finalConfig = ignoredFilesRegexFromEnv("CHEN_JIMPLE_IGNORE_DIRS") match
+      case Some(regex) => baseConfig.withIgnoredFilesRegex(regex)
+      case None        => baseConfig
+    new Jimple2Cpg().createCpgWithOverlays(finalConfig)
 
   private def createJavaSrc2Cpg(config: AtomConfig, outputAtomFile: String): Try[Cpg] =
       new JavaSrc2Cpg().createCpgWithOverlays(
@@ -771,7 +831,7 @@ object Atom:
           delombokMode = Some(DEFAULT_DELOMBOK_MODE)
         )
             .withInputPath(config.inputPath.pathAsString)
-            .withIgnoredFilesRegex(".*(target|build)/(generated|intermediates|outputs|tmp).*")
+            .withIgnoredFilesRegex(ignoredFilesRegex(JAVA_IGNORE_REGEX, "CHEN_JAVA_IGNORE_DIRS"))
             .withOutputPath(outputAtomFile)
       )
 
@@ -782,6 +842,7 @@ object Atom:
           .withInputPath(config.inputPath.pathAsString)
           .withOutputPath(outputAtomFile)
           .withFullResolver(true)
+          .withIgnoredFilesRegex(ignoredFilesRegex("$^", "CHEN_SCALA_IGNORE_DIRS"))
           .withOnlyClasses(true)
           .withDepth(1)
           .withRecurse(true)
@@ -818,9 +879,16 @@ object Atom:
         .withInputPath(config.inputPath.pathAsString)
         .withOutputPath(outputAtomFile)
         .withFlow(config.language.equalsIgnoreCase("FLOW"))
-    val finalConfig = sys.env.get("CHEN_ASTGEN_OUT") match
+    val astGenConfig = sys.env.get("CHEN_ASTGEN_OUT") match
       case Some(dir) => initialConfig.withAstGenOutDir(dir)
       case None      => initialConfig
+    val finalConfig = ignoredFilesRegexFromEnv(
+      "CHEN_JAVASCRIPT_IGNORE_DIRS",
+      "CHEN_JS_IGNORE_DIRS",
+      "CHEN_TYPESCRIPT_IGNORE_DIRS"
+    ) match
+      case Some(regex) => astGenConfig.withIgnoredFilesRegex(regex)
+      case None        => astGenConfig
     new JsSrc2Cpg()
         .createCpgWithOverlays(finalConfig)
         .map { ag =>
@@ -865,7 +933,7 @@ object Atom:
             .withInputPath(config.inputPath.pathAsString)
             .withOutputPath(outputAtomFile)
             .withDefaultIgnoredFilesRegex(List("\\..*".r))
-            .withIgnoredFilesRegex(".*(samples|examples|docs).*")
+            .withIgnoredFilesRegex(ignoredFilesRegex(PHP_IGNORE_REGEX, "CHEN_PHP_IGNORE_DIRS"))
       ).map { ag =>
         new PhpSetKnownTypesPass(ag).createAndApply()
         ag
@@ -876,7 +944,7 @@ object Atom:
         RubyConfig()
             .withInputPath(config.inputPath.pathAsString)
             .withOutputPath(outputAtomFile)
-            .withIgnoredFilesRegex(".*(docs|vendor|spec).*")
+            .withIgnoredFilesRegex(ignoredFilesRegex(RUBY_IGNORE_REGEX, "CHEN_RUBY_IGNORE_DIRS"))
       ).map { ag =>
           ag
       }

--- a/wrapper/nodejs/README.md
+++ b/wrapper/nodejs/README.md
@@ -109,8 +109,19 @@ atom reachables --reuse-atom -o app.atom -s reachables.json -l java .
 
 | Variable                                | Description                                                                                                                                                |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CHEN_IGNORE_TEST_DIRS**               | Set to true to ignore `test` directories. Only supported for Python for now.                                                                               |
-| **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python.                                                                                                  |
+| **CHEN_IGNORE_DIRS**                    | Comma-separated list of directories to ignore for every language frontend.                                                                                 |
+| **CHEN_IGNORE_TEST_DIRS**               | Set to true to ignore common test directories (`test`, `tests`, `mocks`) for every language frontend.                                                     |
+| **CHEN_C_IGNORE_DIRS**                  | Comma-separated list of additional directories to ignore for the C/C++ and header frontends.                                                              |
+| **CHEN_CPP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the C++ frontend.                                                                             |
+| **CHEN_JAVA_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Java source frontend.                                                                     |
+| **CHEN_JIMPLE_IGNORE_DIRS**             | Comma-separated list of directories to ignore for the Jimple/JAR/Android/APK/DEX frontend.                                                                |
+| **CHEN_SCALA_IGNORE_DIRS**              | Comma-separated list of directories to ignore for the Scala frontend.                                                                                      |
+| **CHEN_JAVASCRIPT_IGNORE_DIRS**         | Comma-separated list of directories to ignore for the JavaScript, TypeScript, and Flow frontend.                                                          |
+| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript and TypeScript ignored directories.                                                                                                   |
+| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript ignored directories.                                                                                                                  |
+| **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python. If unset, Atom uses Python's default ignored directories.                                        |
+| **CHEN_PHP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the PHP frontend.                                                                             |
+| **CHEN_RUBY_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Ruby frontend.                                                                            |
 | **CHEN_DELOMBOK_MODE**                  | Delombok mode for the Java frontend (`no-delombok`, `default`, `types-only`, `run-delombok`).                                                              |
 | **CHEN_INCLUDE_PATH**                   | Include directories for the C frontend. Separate paths with `:` or `;`.                                                                                    |
 | **CHEN_ASTGEN_OUT**                     | Existing astgen output directory. Improves performance for JavaScript, TypeScript, and Flow during repeated invocations by reusing existing AST json data. |

--- a/wrapper/nodejs/README.md
+++ b/wrapper/nodejs/README.md
@@ -117,8 +117,8 @@ atom reachables --reuse-atom -o app.atom -s reachables.json -l java .
 | **CHEN_JIMPLE_IGNORE_DIRS**             | Comma-separated list of directories to ignore for the Jimple/JAR/Android/APK/DEX frontend.                                                                |
 | **CHEN_SCALA_IGNORE_DIRS**              | Comma-separated list of directories to ignore for the Scala frontend.                                                                                      |
 | **CHEN_JAVASCRIPT_IGNORE_DIRS**         | Comma-separated list of directories to ignore for the JavaScript, TypeScript, and Flow frontend.                                                          |
-| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript and TypeScript ignored directories.                                                                                                   |
-| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript ignored directories.                                                                                                                  |
+| **CHEN_JS_IGNORE_DIRS**                 | Alias for JavaScript, TypeScript, and Flow ignored directories.                                                                                            |
+| **CHEN_TYPESCRIPT_IGNORE_DIRS**         | Alias for TypeScript and Flow ignored directories.                                                                                                         |
 | **CHEN_PYTHON_IGNORE_DIRS**             | Comma-separated list of directories to ignore for Python. If unset, Atom uses Python's default ignored directories.                                        |
 | **CHEN_PHP_IGNORE_DIRS**                | Comma-separated list of additional directories to ignore for the PHP frontend.                                                                             |
 | **CHEN_RUBY_IGNORE_DIRS**               | Comma-separated list of additional directories to ignore for the Ruby frontend.                                                                            |

--- a/wrapper/nodejs/package-lock.json
+++ b/wrapper/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/atom",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@appthreat/atom-common": "^1.1.0"

--- a/wrapper/nodejs/package.json
+++ b/wrapper/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/atom",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Create atom (⚛) representation for your application, packages and libraries",
   "exports": "./index.js",
   "type": "module",


### PR DESCRIPTION
…ariables for all languages

- Add CHEN_IGNORE_DIRS and language-specific CHEN_*_IGNORE_DIRS env vars for customizable ignored directories across all frontends
- Support CHEN_IGNORE_TEST_DIRS for common test directories in every language
- Refactor ignore logic for consistency and flexibility
- Update documentation to reflect new environment variables
- Bump version to 2.5.4